### PR TITLE
chore: split build and e2e steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,8 @@ jobs:
           max_attempts: 3
           command: npm run test-ci
           timeout_minutes: 20
+      - name: Build
+        run: npm run build:prod
       - name: End-to-End tests
         uses: GabrielBB/xvfb-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ More commands:
 |`npm run electron:mac`|  On a MAC OS, builds your application and generates a `.app` file of your application that can be run on Mac |
 |`npm run test-ci`|  Run unit tests once |
 |`npm run test`|  Run unit tests in watch mode |
+|`npm run e2e`|  Run e2e tests. It requires to run `npm run build:prod` first |
 
 **Note: Only /dist folder and node dependencies will be included in the executable.**
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "ng lint",
     "test": "npm run postinstall:web && ng test",
     "test-ci": "npm run postinstall:web && ng test --watch=false --browsers ChromeHeadless --code-coverage && (cat ./coverage/lcov.info | coveralls || true)",
-    "e2e": "npm run build:prod && cross-env TS_NODE_PROJECT='e2e/tsconfig.e2e.json' mocha --timeout 300000 --require ts-node/register e2e/**/*.e2e.ts",
+    "e2e": "cross-env TS_NODE_PROJECT='e2e/tsconfig.e2e.json' mocha --timeout 300000 --require ts-node/register e2e/**/*.e2e.ts",
     "version": "conventional-changelog -i CHANGELOG.md -s -r 0 && git add CHANGELOG.md"
   },
   "dependencies": {


### PR DESCRIPTION
Advantages:

- Build and e2e steps separated in the CI, so we see which one fails
- So you can build the app once, and run the e2e multiple times without rebuilding