### PR TITLE
Added faction name id to the faction search

### DIFF
--- a/src/app/shared/modules/selectors/faction-selector/faction-selector-modal.component.html
+++ b/src/app/shared/modules/selectors/faction-selector/faction-selector-modal.component.html
@@ -7,6 +7,9 @@
         <div class="form-group col-3">
           <input [formControlName]="'m_ID'" type="number" class="form-control form-control-sm" id="m_ID" placeholder="ID" />
         </div>
+        <div class="form-group col-3">
+          <input [formControlName]="'faction_name_id'" class="form-control form-control-sm" id="faction_name_id" placeholder="Faction" />
+        </div>
         <div class="form-group col-5">
           <input [formControlName]="'m_name_lang_1'" class="form-control form-control-sm" id="m_name_lang_1" placeholder="Faction Name" />
         </div>
@@ -38,6 +41,7 @@
           {{ row.m_ID }}
         </ng-template>
       </ngx-datatable-column>
+      <ngx-datatable-column name="Faction" prop="faction_name_id"></ngx-datatable-column>
       <ngx-datatable-column name="Faction Name" prop="m_name_lang_1"></ngx-datatable-column>
     </ngx-datatable>
   </div>

--- a/src/app/shared/types/faction.type.ts
+++ b/src/app/shared/types/faction.type.ts
@@ -2,9 +2,10 @@ import { TableRow } from './general';
 
 export const FACTION_TABLE = 'factions'; // sqlite
 export const FACTION_ID = 'm_ID';
-export const FACTION_SEARCH_FIELDS = [FACTION_ID, 'm_name_lang_1'];
+export const FACTION_SEARCH_FIELDS = [FACTION_ID, 'faction_name_id', 'm_name_lang_1'];
 
 export class Faction extends TableRow {
   m_ID: number = 0;
   m_name_lang_1: string = '';
+  faction_name_id: number = 0;
 }


### PR DESCRIPTION
I added a new field on the faction table, so when people want to edit the faction they will find the correct faction id, instead of the database id (which are not the same :P).

This PR however is not done, because i still dont know how to link the acore faction:faction to the new field i created(faction_name_id).

Test of the new change:

![image](https://user-images.githubusercontent.com/87535580/134643700-74f82a55-a7e4-40e4-8fd5-fa3c9336a675.png)

I changed the SQlite database by doing the alter:

ALTER TABLE factions ADD COLUMN faction_name_id INTEGER NOT NULL DEFAULT '0';

I dont know if the database changes have a proper pull request, but the gitHub commit added the whole database. So if you want to know what changed it was that.

Please let me know how to link it or anything you see that can be improved,