### PR TITLE
Modify information in README.md about MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ _Client does not support authentication protocol requested by server; consider u
 Before logging using Keira in remember to run this query on your database for your desired users:
 
 ```
-ALTER USER 'acore' IDENTIFIED WITH mysql_native_password BY 'acore';
+ALTER USER 'acore'@'localhost' IDENTIFIED WITH mysql_native_password BY 'acore';
 flush privileges;
 ```
+
+- The first `acore` refers to the user. Which uses AzerothCore by default.
+- `localhost`, is the type of connection.
+- The second `acore`, is the password, which by default is that.
 
 [More information about this issue here](https://stackoverflow.com/questions/50093144/mysql-8-0-client-does-not-support-authentication-protocol-requested-by-server)
 


### PR DESCRIPTION
- The SQL statement is modified.
- Field information is added.

Currently, when using MySQL 8.x, it is necessary to change the encryption as specified in the readme, however, the connection type must be clarified, which is what I am adding. Take this opportunity to upload a detail of what the values mean within the SQL statement.
