### PR TITLE
fix(creature): adapt to removed InhabitType column

### DIFF
--- a/src/app/features/creature/creature-template/creature-template.component.html
+++ b/src/app/features/creature/creature-template/creature-template.component.html
@@ -518,14 +518,6 @@
             <input [formControlName]="'movementId'" id="movementId" type="number" class="form-control form-control-sm" />
           </div>
           <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
-            <label class="control-label" for="InhabitType">InhabitType</label>
-            <keira-flags-selector-btn
-              [control]="editorService.form.controls.InhabitType"
-              [config]="{ flags: INHABIT_TYPE, name: 'InhabitType' }"
-            ></keira-flags-selector-btn>
-            <input [formControlName]="'InhabitType'" id="InhabitType" type="number" class="form-control form-control-sm" />
-          </div>
-          <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
             <label class="control-label" for="HoverHeight">HoverHeight</label>
             <i
               class="fas fa-info-circle ms-1"

--- a/src/app/features/creature/creature-template/creature-template.component.ts
+++ b/src/app/features/creature/creature-template/creature-template.component.ts
@@ -5,7 +5,6 @@ import { CreatureTemplate } from '@keira-types/creature-template.type';
 import { SingleRowEditorComponent } from '@keira-abstract/components/editors/single-row-editor.component';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { UNIT_FLAGS_2 } from '@keira-constants/flags/unit-flags2';
-import { INHABIT_TYPE } from '@keira-constants/flags/inhabit-type';
 import { TRAINER_TYPE } from '@keira-constants/options/trainer-type';
 import { NPC_FLAGS } from '@keira-constants/flags/npc-flags';
 import { CREATURE_FAMILY } from '@keira-constants/options/creature-family';
@@ -34,7 +33,6 @@ import { CREATURE_AI_NAME } from '@keira-constants/options/creature-ai-name';
 export class CreatureTemplateComponent extends SingleRowEditorComponent<CreatureTemplate> {
   public readonly UNIT_FLAGS = UNIT_FLAGS;
   public readonly UNIT_FLAGS_2 = UNIT_FLAGS_2;
-  public readonly INHABIT_TYPE = INHABIT_TYPE;
   public readonly TRAINER_TYPE = TRAINER_TYPE;
   public readonly NPC_FLAGS = NPC_FLAGS;
   public readonly CREATURE_FAMILY = CREATURE_FAMILY;

--- a/src/app/features/creature/creature-template/creature-template.integration.spec.ts
+++ b/src/app/features/creature/creature-template/creature-template.integration.spec.ts
@@ -32,11 +32,11 @@ describe('CreatureTemplate integration tests', () => {
     '`scale`, `rank`, `dmgschool`, `DamageModifier`, `BaseAttackTime`, `RangeAttackTime`, `BaseVariance`, `RangeVariance`, ' +
     '`unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `trainer_type`, `trainer_spell`, `trainer_class`, ' +
     '`trainer_race`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `PetSpellDataId`, `VehicleId`, `mingold`, ' +
-    '`maxgold`, `AIName`, `MovementType`, `InhabitType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `ExperienceModifier`, ' +
+    '`maxgold`, `AIName`, `MovementType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `ExperienceModifier`, ' +
     '`RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `spell_school_immune_mask`, ' +
     '`flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES\n' +
     "(1234, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', '', 0, 1, 1, 0, 0, 0, 1, 1.14286, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, " +
-    "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 3, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, '', 0);\n";
+    "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, '', 0);\n";
 
   const originalEntity = new CreatureTemplate();
   originalEntity.entry = id;
@@ -86,10 +86,10 @@ describe('CreatureTemplate integration tests', () => {
         '`RangeVariance`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, ' +
         '`trainer_type`, `trainer_spell`, `trainer_class`, `trainer_race`, `type`, `type_flags`, ' +
         '`lootid`, `pickpocketloot`, `skinloot`, `PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, ' +
-        '`AIName`, `MovementType`, `InhabitType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `ExperienceModifier`, `RacialLeader`, ' +
+        '`AIName`, `MovementType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `ExperienceModifier`, `RacialLeader`, ' +
         '`movementId`, `RegenHealth`, `mechanic_immune_mask`, `spell_school_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES\n' +
         "(1234, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Shin', '', '', 0, 1, 1, 0, 0, 0, 1, 1.14286, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0," +
-        " 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 3, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, '', 0);";
+        " 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, '', 0);";
 
       querySpy.calls.reset();
 
@@ -131,9 +131,9 @@ describe('CreatureTemplate integration tests', () => {
         '`RangeVariance` = 28, `unit_class` = 29, `unit_flags` = 30, `unit_flags2` = 31, `dynamicflags` = 32, `family` = 33, ' +
         '`trainer_type` = 34, `trainer_spell` = 35, `trainer_class` = 36, `trainer_race` = 37, `type` = 38, `type_flags` = 39, ' +
         '`lootid` = 40, `pickpocketloot` = 41, `skinloot` = 42, `PetSpellDataId` = 43, `VehicleId` = 44, ' +
-        "`mingold` = 45, `maxgold` = 46, `AIName` = '47', `MovementType` = 48, `InhabitType` = 49, `HoverHeight` = 50, " +
-        '`HealthModifier` = 51, `ManaModifier` = 52, `ArmorModifier` = 53, `ExperienceModifier` = 54, `RacialLeader` = 55, `movementId` = 56, `RegenHealth` = 57, ' +
-        "`mechanic_immune_mask` = 58, `spell_school_immune_mask` = 59, `flags_extra` = 60, `ScriptName` = '61' WHERE (`entry` = 1234);";
+        "`mingold` = 45, `maxgold` = 46, `AIName` = '47', `MovementType` = 48, `HoverHeight` = 49, " +
+        '`HealthModifier` = 50, `ManaModifier` = 51, `ArmorModifier` = 52, `ExperienceModifier` = 53, `RacialLeader` = 54, `movementId` = 55, `RegenHealth` = 56, ' +
+        "`mechanic_immune_mask` = 57, `spell_school_immune_mask` = 58, `flags_extra` = 59, `ScriptName` = '60' WHERE (`entry` = 1234);";
 
       querySpy.calls.reset();
 

--- a/src/app/shared/types/creature-template.type.ts
+++ b/src/app/shared/types/creature-template.type.ts
@@ -61,7 +61,6 @@ export class CreatureTemplate extends TableRow {
   maxgold: number = 0;
   AIName: string = '';
   MovementType: number = 0;
-  InhabitType: number = 3;
   HoverHeight: number = 1;
   HealthModifier: number = 1;
   ManaModifier: number = 1;


### PR DESCRIPTION
### Proposed Changes: 
With https://github.com/azerothcore/azerothcore-wotlk/pull/9272 the column `InhabitType` from the `creature_template` table was removed. This PR adapts Keira3 to these changes.

### ToDo
An editor component for the new table `creature_template_movement` should be created. 