### PR TITLE
feat(creature): creature-template-movement

### DIFF
--- a/src/app/config/app-routing.module.ts
+++ b/src/app/config/app-routing.module.ts
@@ -8,6 +8,7 @@ import { CreatureTemplateComponent } from '../features/creature/creature-templat
 import { CreatureTemplateAddonComponent } from '../features/creature/creature-template-addon/creature-template-addon.component';
 import { CreatureTemplateResistanceComponent } from '../features/creature/creature-template-resistance/creature-template-resistance.component';
 import { CreatureTemplateSpellComponent } from '../features/creature/creature-template-spell/creature-template-spell.component';
+import { CreatureTemplateMovementComponent } from '../features/creature/creature-template-movement/creature-template-movement.component';
 import { NpcVendorComponent } from '../features/creature/npc-vendor/npc-vendor.component';
 import { CreatureEquipTemplateComponent } from '../features/creature/creature-equip-template/creature-equip-template.component';
 import { CreatureOnkillReputationComponent } from '../features/creature/creature-onkill-reputation/creature-onkill-reputation.component';
@@ -108,6 +109,11 @@ const routes: Routes = [
       {
         path: 'creature-template-spell',
         component: CreatureTemplateSpellComponent,
+        canActivate: [CreatureHandlerService],
+      },
+      {
+        path: 'creature-template-movement',
+        component: CreatureTemplateMovementComponent,
         canActivate: [CreatureHandlerService],
       },
       {

--- a/src/app/features/creature/creature-handler.service.ts
+++ b/src/app/features/creature/creature-handler.service.ts
@@ -7,6 +7,7 @@ import { SaiCreatureHandlerService } from './sai-creature-handler.service';
 import { CREATURE_TEMPLATE_ADDON_TABLE } from '@keira-types/creature-template-addon.type';
 import { CREATURE_TEMPLATE_RESISTANCE_TABLE } from '@keira-types/creature-template-resistance.type';
 import { CREATURE_TEMPLATE_SPELL_TABLE } from '@keira-types/creature-template-spell.type';
+import { CREATURE_TEMPLATE_MOVEMENT_TABLE } from '@keira-types/creature-template-movement.type';
 import { CREATURE_ONKLL_REPUTATION_TABLE } from '@keira-types/creature-onkill-reputation.type';
 import { CREATURE_EQUIP_TEMPLATE_TABLE } from '@keira-types/creature-equip-template.type';
 import { NPC_VENDOR_TABLE } from '@keira-types/npc-vendor.type';
@@ -32,6 +33,9 @@ export class CreatureHandlerService extends HandlerService<CreatureTemplate> {
   }
   get isCreatureTemplateSpellUnsaved(): boolean {
     return this.statusMap[CREATURE_TEMPLATE_SPELL_TABLE];
+  }
+  get isCreatureTemplateMovementUnsaved(): boolean {
+    return this.statusMap[CREATURE_TEMPLATE_MOVEMENT_TABLE];
   }
   get isCreatureOnkillReputationUnsaved(): boolean {
     return this.statusMap[CREATURE_ONKLL_REPUTATION_TABLE];
@@ -72,6 +76,7 @@ export class CreatureHandlerService extends HandlerService<CreatureTemplate> {
     [CREATURE_TEMPLATE_ADDON_TABLE]: false,
     [CREATURE_TEMPLATE_RESISTANCE_TABLE]: false,
     [CREATURE_TEMPLATE_SPELL_TABLE]: false,
+    [CREATURE_TEMPLATE_MOVEMENT_TABLE]: false,
     [CREATURE_ONKLL_REPUTATION_TABLE]: false,
     [CREATURE_EQUIP_TEMPLATE_TABLE]: false,
     [NPC_VENDOR_TABLE]: false,

--- a/src/app/features/creature/creature-template-movement/creature-template-movement.component.html
+++ b/src/app/features/creature/creature-template-movement/creature-template-movement.component.html
@@ -1,0 +1,66 @@
+<keira-top-bar [handler]="handlerService"></keira-top-bar>
+
+<div class="container-fluid">
+  <span *ngIf="editorService.loading">Loading...</span>
+
+  <div *ngIf="editorService.form && !!editorService.loadedEntityId && !editorService.loading">
+    <div class="content-block">
+      <keira-query-output
+        [docUrl]="docUrl"
+        [editorService]="editorService"
+        (executeQuery)="editorService.save($event)"
+      ></keira-query-output>
+    </div>
+
+    <form [formGroup]="editorService.form" class="form-group edit-form">
+      <div class="content-block">
+        <div class="row">
+          <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
+            <label class="control-label" for="Ground">Ground</label>
+            <i class="fas fa-info-circle ms-1" [placement]="'auto'" [tooltip]="'0 = None; 1 = Run; 2 = Hover'"></i>
+            <input [formControlName]="'Ground'" id="Ground" type="number" class="form-control form-control-sm" />
+          </div>
+          <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
+            <label class="control-label" for="Swim">Swim</label>
+            <i class="fas fa-info-circle ms-1" [placement]="'auto'" [tooltip]="'0 = None; 1 = Swim'"></i>
+            <input [formControlName]="'Swim'" id="Swim" type="number" class="form-control form-control-sm" />
+          </div>
+          <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
+            <label class="control-label" for="Flight">Flight</label>
+            <i class="fas fa-info-circle ms-1" [placement]="'auto'" [tooltip]="'0 = None; 1 = Disable Gravity; 2 = CanFly'"></i>
+            <input [formControlName]="'Flight'" id="Flight" type="number" class="form-control form-control-sm" />
+          </div>
+          <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
+            <label class="control-label" for="Rooted">Rooted</label>
+            <i class="fas fa-info-circle ms-1" [placement]="'auto'" [tooltip]="'0 = None; 1 = Rooted; '"></i>
+            <input [formControlName]="'Rooted'" id="Rooted" type="number" class="form-control form-control-sm" />
+          </div>
+          <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
+            <label class="control-label" for="Chase">Chase</label>
+            <i class="fas fa-info-circle ms-1" [placement]="'auto'" [tooltip]="'0 = Run; 1 = CanWalk; 2 = AlwaysWalk'"></i>
+            <input [formControlName]="'Chase'" id="Chase" type="number" class="form-control form-control-sm" />
+          </div>
+          <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
+            <label class="control-label" for="Random">Random</label>
+            <i class="fas fa-info-circle ms-1" [placement]="'auto'" [tooltip]="'0 = Walk; 1 = CanRun; 2 = AlwaysRun'"></i>
+            <input [formControlName]="'Random'" id="Random" type="number" class="form-control form-control-sm" />
+          </div>
+          <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
+            <label class="control-label" for="InteractionPauseTimer">InteractionPauseTimer</label>
+            <i
+              class="fas fa-info-circle ms-1"
+              [placement]="'auto'"
+              [tooltip]="'Time (in milliseconds) during which creature will not move after interaction with player'"
+            ></i>
+            <input
+              [formControlName]="'InteractionPauseTimer'"
+              id="InteractionPauseTimer"
+              type="number"
+              class="form-control form-control-sm"
+            />
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/src/app/features/creature/creature-template-movement/creature-template-movement.component.ts
+++ b/src/app/features/creature/creature-template-movement/creature-template-movement.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+
+import { SingleRowEditorComponent } from '@keira-abstract/components/editors/single-row-editor.component';
+import { CreatureHandlerService } from '../creature-handler.service';
+import { CreatureTemplateMovement } from '@keira-types/creature-template-movement.type';
+import { CreatureTemplateMovementService } from './creature-template-movement.service';
+import { CREATURE_TEMPLATE_RESISTANCE_TABLE } from '@keira-types/creature-template-resistance.type';
+
+@Component({
+  selector: 'keira-creature-template-movement',
+  templateUrl: './creature-template-movement.component.html',
+})
+export class CreatureTemplateMovementComponent extends SingleRowEditorComponent<CreatureTemplateMovement> {
+  public get docUrl(): string {
+    return this.WIKI_BASE_URL + CREATURE_TEMPLATE_RESISTANCE_TABLE;
+  }
+
+  /* istanbul ignore next */ // because of: https://github.com/gotwarlost/istanbul/issues/690
+  constructor(public editorService: CreatureTemplateMovementService, public handlerService: CreatureHandlerService) {
+    super(editorService, handlerService);
+  }
+}

--- a/src/app/features/creature/creature-template-movement/creature-template-movement.integration.spec.ts
+++ b/src/app/features/creature/creature-template-movement/creature-template-movement.integration.spec.ts
@@ -1,0 +1,150 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { ToastrModule } from 'ngx-toastr';
+import { ModalModule } from 'ngx-bootstrap/modal';
+import Spy = jasmine.Spy;
+
+import { MysqlQueryService } from '@keira-shared/services/mysql-query.service';
+import { CreatureTemplateMovementComponent } from './creature-template-movement.component';
+import { CreatureTemplateMovementModule } from './creature-template-movement.module';
+import { EditorPageObject } from '@keira-testing/editor-page-object';
+import { CreatureHandlerService } from '../creature-handler.service';
+import { CreatureTemplateMovement } from '@keira-types/creature-template-movement.type';
+import { SaiCreatureHandlerService } from '../sai-creature-handler.service';
+
+class CreatureTemplateMovementPage extends EditorPageObject<CreatureTemplateMovementComponent> {}
+
+describe('CreatureTemplateMovement integration tests', () => {
+  let component: CreatureTemplateMovementComponent;
+  let fixture: ComponentFixture<CreatureTemplateMovementComponent>;
+  let queryService: MysqlQueryService;
+  let querySpy: Spy;
+  let handlerService: CreatureHandlerService;
+  let page: CreatureTemplateMovementPage;
+
+  const id = 1234;
+  const expectedFullCreateQuery =
+    'DELETE FROM `creature_template_movement` WHERE (`CreatureId` = 1234);\n' +
+    'INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES\n' +
+    '(1234, 0, 1, 3, 2, 0, 2, 0);';
+
+  const originalEntity = new CreatureTemplateMovement();
+  originalEntity.CreatureId = id;
+  originalEntity.Ground = 0;
+  originalEntity.Swim = 1;
+  originalEntity.Flight = 3;
+  originalEntity.Rooted = 2;
+  originalEntity.Chase = 0;
+  originalEntity.Random = 2;
+  originalEntity.InteractionPauseTimer = 0;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ToastrModule.forRoot(), ModalModule.forRoot(), CreatureTemplateMovementModule, RouterTestingModule],
+        providers: [CreatureHandlerService, SaiCreatureHandlerService],
+      }).compileComponents();
+    }),
+  );
+
+  function setup(creatingNew: boolean) {
+    handlerService = TestBed.inject(CreatureHandlerService);
+    handlerService['_selected'] = `${id}`;
+    handlerService.isNew = creatingNew;
+
+    queryService = TestBed.inject(MysqlQueryService);
+    querySpy = spyOn(queryService, 'query').and.returnValue(of([]));
+
+    spyOn(queryService, 'selectAll').and.returnValue(of(creatingNew ? [] : [originalEntity]));
+
+    fixture = TestBed.createComponent(CreatureTemplateMovementComponent);
+    component = fixture.componentInstance;
+    page = new CreatureTemplateMovementPage(fixture);
+    fixture.autoDetectChanges(true);
+    fixture.detectChanges();
+  }
+
+  describe('Creating new', () => {
+    beforeEach(() => setup(true));
+
+    it('should correctly initialise', () => {
+      page.expectQuerySwitchToBeHidden();
+      page.expectFullQueryToBeShown();
+      page.expectFullQueryToContain(expectedFullCreateQuery);
+    });
+
+    it('should correctly update the unsaved status', () => {
+      const field = 'path_id';
+      expect(handlerService.isCreatureTemplateMovementUnsaved).toBe(false);
+      page.setInputValueById(field, 3);
+      expect(handlerService.isCreatureTemplateMovementUnsaved).toBe(true);
+      page.setInputValueById(field, 0);
+      expect(handlerService.isCreatureTemplateMovementUnsaved).toBe(false);
+    });
+
+    it('changing a property and executing the query should correctly work', () => {
+      const expectedQuery =
+        'DELETE FROM `creature_template_movement` WHERE (`CreatureId` = 1234);\n' +
+        'INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES\n' +
+        '(1234, 1, 1, 3, 2, 0, 2, 0);';
+      querySpy.calls.reset();
+
+      page.setInputValueById('Ground', 1);
+      page.expectFullQueryToContain(expectedQuery);
+
+      page.clickExecuteQuery();
+
+      expect(querySpy).toHaveBeenCalledTimes(1);
+      expect(querySpy.calls.mostRecent().args[0]).toContain(expectedQuery);
+    });
+  });
+
+  describe('Editing existing', () => {
+    beforeEach(() => setup(false));
+
+    it('should correctly initialise', () => {
+      page.expectDiffQueryToBeShown();
+      page.expectDiffQueryToBeEmpty();
+      page.expectFullQueryToContain(
+        'DELETE FROM `creature_template_movement` WHERE (`CreatureId` = 1234);\n' +
+          'INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES\n' +
+          '(1234, 0, 0, 0, 0, 0, 0, 0);',
+      );
+    });
+
+    it('changing all properties and executing the query should correctly work', () => {
+      const expectedQuery =
+        'UPDATE `creature_template_movement` SET ' +
+        "`Ground` = 0, `Swim` = 1, `Flight` = 2, `Rooted` = 2, `Chase` = 1, `Random` = 1, `InteractionPauseTimer` = '0' WHERE (`entry` = 1234);";
+      querySpy.calls.reset();
+
+      page.changeAllFields(originalEntity);
+      page.expectDiffQueryToContain(expectedQuery);
+
+      page.clickExecuteQuery();
+      expect(querySpy).toHaveBeenCalledTimes(1);
+      expect(querySpy.calls.mostRecent().args[0]).toContain(expectedQuery);
+    });
+
+    it('changing values should correctly update the queries', () => {
+      page.setInputValueById('Ground', '1');
+      page.expectDiffQueryToContain('UPDATE `creature_template_movement` SET `Ground` = 1 WHERE (`entry` = 1234);');
+      page.expectFullQueryToContain(
+        'DELETE FROM `creature_template_movement` WHERE (`entry` = 1234);\n' +
+          'INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES\n' +
+          '(1234, 1, 1, 3, 2, 0, 2, 0);',
+      );
+
+      page.setInputValueById('InteractionPauseTimer', '2');
+      page.expectDiffQueryToContain(
+        'UPDATE `creature_template_movement` SET `Ground` = 3, `InteractionPauseTimer` = 2 WHERE (`entry` = 1234);',
+      );
+      page.expectFullQueryToContain(
+        'DELETE FROM `creature_template_movement` WHERE (`entry` = 1234);\n' +
+          'INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES\n' +
+          '(1234, 3, 1, 3, 2, 0, 2, 2);\n',
+      );
+    });
+  });
+});

--- a/src/app/features/creature/creature-template-movement/creature-template-movement.integration.spec.ts
+++ b/src/app/features/creature/creature-template-movement/creature-template-movement.integration.spec.ts
@@ -27,7 +27,7 @@ describe('CreatureTemplateMovement integration tests', () => {
   const expectedFullCreateQuery =
     'DELETE FROM `creature_template_movement` WHERE (`CreatureId` = 1234);\n' +
     'INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES\n' +
-    '(1234, 0, 1, 3, 2, 0, 2, 0);';
+    '(1234, 0, 0, 0, 0, 0, 0, 0);';
 
   const originalEntity = new CreatureTemplateMovement();
   originalEntity.CreatureId = id;
@@ -75,7 +75,7 @@ describe('CreatureTemplateMovement integration tests', () => {
     });
 
     it('should correctly update the unsaved status', () => {
-      const field = 'path_id';
+      const field = 'Ground';
       expect(handlerService.isCreatureTemplateMovementUnsaved).toBe(false);
       page.setInputValueById(field, 3);
       expect(handlerService.isCreatureTemplateMovementUnsaved).toBe(true);
@@ -87,7 +87,7 @@ describe('CreatureTemplateMovement integration tests', () => {
       const expectedQuery =
         'DELETE FROM `creature_template_movement` WHERE (`CreatureId` = 1234);\n' +
         'INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES\n' +
-        '(1234, 1, 1, 3, 2, 0, 2, 0);';
+        '(1234, 1, 0, 0, 0, 0, 0, 0);';
       querySpy.calls.reset();
 
       page.setInputValueById('Ground', 1);
@@ -109,17 +109,16 @@ describe('CreatureTemplateMovement integration tests', () => {
       page.expectFullQueryToContain(
         'DELETE FROM `creature_template_movement` WHERE (`CreatureId` = 1234);\n' +
           'INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES\n' +
-          '(1234, 0, 0, 0, 0, 0, 0, 0);',
+          '(1234, 0, 1, 3, 2, 0, 2, 0);',
       );
     });
 
     it('changing all properties and executing the query should correctly work', () => {
       const expectedQuery =
-        'UPDATE `creature_template_movement` SET ' +
-        "`Ground` = 0, `Swim` = 1, `Flight` = 2, `Rooted` = 2, `Chase` = 1, `Random` = 1, `InteractionPauseTimer` = '0' WHERE (`entry` = 1234);";
+        'UPDATE `creature_template_movement` SET `Flight` = 2, `Rooted` = 3, `Chase` = 4, `Random` = 5, `InteractionPauseTimer` = 6 WHERE (`CreatureId` = 1234);';
       querySpy.calls.reset();
 
-      page.changeAllFields(originalEntity);
+      page.changeAllFields(originalEntity, ['CreatureId']);
       page.expectDiffQueryToContain(expectedQuery);
 
       page.clickExecuteQuery();
@@ -129,21 +128,21 @@ describe('CreatureTemplateMovement integration tests', () => {
 
     it('changing values should correctly update the queries', () => {
       page.setInputValueById('Ground', '1');
-      page.expectDiffQueryToContain('UPDATE `creature_template_movement` SET `Ground` = 1 WHERE (`entry` = 1234);');
+      page.expectDiffQueryToContain('UPDATE `creature_template_movement` SET `Ground` = 1 WHERE (`CreatureId` = 1234);');
       page.expectFullQueryToContain(
-        'DELETE FROM `creature_template_movement` WHERE (`entry` = 1234);\n' +
+        'DELETE FROM `creature_template_movement` WHERE (`CreatureId` = 1234);\n' +
           'INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES\n' +
           '(1234, 1, 1, 3, 2, 0, 2, 0);',
       );
 
       page.setInputValueById('InteractionPauseTimer', '2');
       page.expectDiffQueryToContain(
-        'UPDATE `creature_template_movement` SET `Ground` = 3, `InteractionPauseTimer` = 2 WHERE (`entry` = 1234);',
+        'UPDATE `creature_template_movement` SET `Ground` = 1, `InteractionPauseTimer` = 2 WHERE (`CreatureId` = 1234);',
       );
       page.expectFullQueryToContain(
-        'DELETE FROM `creature_template_movement` WHERE (`entry` = 1234);\n' +
+        'DELETE FROM `creature_template_movement` WHERE (`CreatureId` = 1234);\n' +
           'INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES\n' +
-          '(1234, 3, 1, 3, 2, 0, 2, 2);\n',
+          '(1234, 1, 1, 3, 2, 0, 2, 2);\n',
       );
     });
   });

--- a/src/app/features/creature/creature-template-movement/creature-template-movement.module.ts
+++ b/src/app/features/creature/creature-template-movement/creature-template-movement.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ToastrModule } from 'ngx-toastr';
+import { toastrConfig } from '@keira-config/toastr.config';
+
+import { TopBarModule } from '@keira-shared/modules/top-bar/top-bar.module';
+import { QueryOutputModule } from '@keira-shared/modules/query-output/query-output.module';
+import { CreatureTemplateMovementComponent } from './creature-template-movement.component';
+import { SingleValueSelectorModule } from '@keira-shared/modules/selectors/single-value-selector/single-value-selector.module';
+import { CreatureTemplateMovementService } from './creature-template-movement.service';
+
+@NgModule({
+  declarations: [CreatureTemplateMovementComponent],
+  imports: [BrowserModule, ReactiveFormsModule, TopBarModule, QueryOutputModule, TooltipModule, ToastrModule, SingleValueSelectorModule],
+  exports: [CreatureTemplateMovementComponent],
+  providers: [CreatureTemplateMovementService],
+})
+export class CreatureTemplateMovementModule {}

--- a/src/app/features/creature/creature-template-movement/creature-template-movement.service.spec.ts
+++ b/src/app/features/creature/creature-template-movement/creature-template-movement.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { instance } from 'ts-mockito';
+import { ToastrService } from 'ngx-toastr';
+
+import { CreatureTemplateMovementService } from './creature-template-movement.service';
+import { MysqlQueryService } from '@keira-shared/services/mysql-query.service';
+import { MockedMysqlQueryService, MockedToastrService } from '@keira-testing/mocks';
+import { CreatureHandlerService } from '../creature-handler.service';
+import { SaiCreatureHandlerService } from '../sai-creature-handler.service';
+
+describe('CreatureTemplateMovementService', () => {
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        { provide: MysqlQueryService, useValue: instance(MockedMysqlQueryService) },
+        { provide: ToastrService, useValue: instance(MockedToastrService) },
+        CreatureHandlerService,
+        SaiCreatureHandlerService,
+        CreatureTemplateMovementService,
+      ],
+    }),
+  );
+
+  it('should be created', () => {
+    const service: CreatureTemplateMovementService = TestBed.inject(CreatureTemplateMovementService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/features/creature/creature-template-movement/creature-template-movement.service.ts
+++ b/src/app/features/creature/creature-template-movement/creature-template-movement.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { ToastrService } from 'ngx-toastr';
+
+import { CreatureHandlerService } from '../creature-handler.service';
+import { MysqlQueryService } from '@keira-shared/services/mysql-query.service';
+import { SingleRowEditorService } from '@keira-abstract/service/editors/single-row-editor.service';
+import {
+  CREATURE_TEMPLATE_MOVEMENT_ID,
+  CREATURE_TEMPLATE_MOVEMENT_TABLE,
+  CreatureTemplateMovement,
+} from '@keira-types/creature-template-movement.type';
+
+@Injectable()
+export class CreatureTemplateMovementService extends SingleRowEditorService<CreatureTemplateMovement> {
+  /* istanbul ignore next */ // because of: https://github.com/gotwarlost/istanbul/issues/690
+  constructor(
+    protected handlerService: CreatureHandlerService,
+    public readonly queryService: MysqlQueryService,
+    protected toastrService: ToastrService,
+  ) {
+    super(
+      CreatureTemplateMovement,
+      CREATURE_TEMPLATE_MOVEMENT_TABLE,
+      CREATURE_TEMPLATE_MOVEMENT_ID,
+      null,
+      false,
+      handlerService,
+      queryService,
+      toastrService,
+    );
+  }
+}

--- a/src/app/features/creature/creature.module.ts
+++ b/src/app/features/creature/creature.module.ts
@@ -7,6 +7,7 @@ import { CreatureTemplateModule } from './creature-template/creature-template.mo
 import { CreatureTemplateAddonModule } from './creature-template-addon/creature-template-addon.module';
 import { CreatureTemplateResistanceModule } from './creature-template-resistance/creature-template-resistance.module';
 import { CreatureTemplateSpellModule } from './creature-template-spell/creature-template-spell.module';
+import { CreatureTemplateMovementModule } from './creature-template-movement/creature-template-movement.module';
 import { NpcTrainerModule } from './npc-trainer/npc-trainer.module';
 import { PickpocketingLootTemplateModule } from './pickpocketing-loot-template/pickpocketing-loot-template.module';
 import { SelectCreatureModule } from './select-creature/select-creature.module';
@@ -27,6 +28,7 @@ const modules = [
   CreatureTemplateAddonModule,
   CreatureTemplateResistanceModule,
   CreatureTemplateSpellModule,
+  CreatureTemplateMovementModule,
   CreatureQuestitemModule,
   NpcTrainerModule,
   NpcVendorModule,

--- a/src/app/main/main-window/sidebar/sidebar.component.html
+++ b/src/app/main/main-window/sidebar/sidebar.component.html
@@ -84,6 +84,12 @@
                       </a>
                     </li>
                     <li>
+                      <a href="#" routerLinkActive="active" [routerLink]="'creature/creature-template-movement'">
+                        Template Movement
+                        <keira-unsaved-icon *ngIf="creatureHandlerService.isCreatureTemplateMovementUnsaved"></keira-unsaved-icon>
+                      </a>
+                    </li>
+                    <li>
                       <a href="#" routerLinkActive="active" [routerLink]="'creature/creature-onkill-reputation'">
                         Onkill Reputation
                         <keira-unsaved-icon *ngIf="creatureHandlerService.isCreatureOnkillReputationUnsaved"></keira-unsaved-icon>

--- a/src/app/shared/types/creature-template-movement.type.ts
+++ b/src/app/shared/types/creature-template-movement.type.ts
@@ -1,0 +1,15 @@
+import { TableRow } from './general';
+
+export const CREATURE_TEMPLATE_MOVEMENT_TABLE = 'creature_template_movement';
+export const CREATURE_TEMPLATE_MOVEMENT_ID = 'CreatureId';
+
+export class CreatureTemplateMovement extends TableRow {
+  CreatureId: number = 0;
+  Ground: number = 0;
+  Swim: number = 0;
+  Flight: number = 0;
+  Rooted: number = 0;
+  Chase: number = 0;
+  Random: number = 0;
+  InteractionPauseTimer: number = 0;
+}


### PR DESCRIPTION
### Proposed changes
This PR adds functionality for the [creature_template_movement](https://www.azerothcore.org/wiki/creature_template_movement) table. The table is now editable in the editor.

![image](https://user-images.githubusercontent.com/10009755/149007761-86cf627c-0a67-4124-b4ae-4b29baa73ba8.png)


The tests I added seem to pass, but I'm not really familiar with the testing library which gets used.

### How to test
Select a random creature and look at the **Template Movement** tab which you can find in the Creature submenu.

To see auto-population from the database select the creature with the ID **40468**.