### PR TITLE
feat(spell): spell_dbc editor additions

### DIFF
--- a/src/app/features/spell/spell-dbc/base/spell-dbc-base.component.html
+++ b/src/app/features/spell/spell-dbc/base/spell-dbc-base.component.html
@@ -184,6 +184,11 @@
 
     <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
       <label class="control-label" for="PowerType">PowerType</label>
+      <keira-single-value-selector-btn
+        [control]="formGroup.controls.PowerType"
+        [config]="{ options: SPELL_DBC_POWER_TYPE, name: 'PowerType' }"
+        [modalClass]="'modal-md'"
+      ></keira-single-value-selector-btn>
       <i class="fas fa-info-circle ms-1" [placement]="'auto'" [tooltip]="'Power type used by spell.'"></i>
       <input [formControlName]="'PowerType'" id="PowerType" type="number" class="form-control form-control-sm" />
     </div>

--- a/src/app/features/spell/spell-dbc/base/spell-dbc-base.component.ts
+++ b/src/app/features/spell/spell-dbc/base/spell-dbc-base.component.ts
@@ -8,6 +8,7 @@ import { SPELL_DBC_FACING_FRONT_FLAG } from '@keira-shared/constants/flags/spell
 import { DISPEL_TYPE } from '@keira-shared/constants/options/dispel-type';
 import { SPELL_MECHANIC } from '@keira-shared/constants/options/spell-mechanic';
 import { TOTEM_CATEGORY } from '@keira-shared/constants/options/totem-category';
+import { SPELL_DBC_POWER_TYPE } from '@keira-shared/constants/options/spell_dbc_power_type';
 
 @Component({
   selector: 'keira-spell-dbc-base',
@@ -19,6 +20,7 @@ export class SpellDbcBaseComponent {
   readonly DISPEL_TYPE = DISPEL_TYPE;
   readonly SPELL_MECHANIC = SPELL_MECHANIC;
   readonly TOTEM_CATEGORY = TOTEM_CATEGORY;
+  readonly SPELL_DBC_POWER_TYPE = SPELL_DBC_POWER_TYPE;
 
   @Input() formGroup: FormGroup<SpellDbc>;
 }

--- a/src/app/shared/constants/options/spell_dbc_power_type.ts
+++ b/src/app/shared/constants/options/spell_dbc_power_type.ts
@@ -1,0 +1,18 @@
+import { Option } from '../../types/general';
+
+export const SPELL_DBC_POWER_TYPE: Option[] = [
+  { value: 0, name: 'Mana' },
+  { value: 1, name: 'Rage' },
+  { value: 2, name: 'Focus (Pet)' },
+  { value: 3, name: 'Energy' },
+  { value: 4, name: 'Happiness' },
+  { value: 5, name: 'Runes' },
+  { value: 6, name: 'Runic Power' },
+  { value: 7, name: 'Steam' },
+  { value: 8, name: 'Pyrite' },
+  { value: 9, name: 'Heat' },
+  { value: 10, name: 'Ooze' },
+  { value: 11, name: 'Blood' },
+  { value: 12, name: 'Wrath' },
+  { value: 13, name: 'Health' },
+];


### PR DESCRIPTION
### Proposed changes
This PR adds additional functionality to the spell_dbc editor.
Information is taken directly from stoneharries SpellEditor as it seems to be more up to date than wowdev.wiki.

### List of changes
#### Base
- added PowerType selector