### PR TITLE
fix: adapt sidebar icon styling to fontawesome 6

### DIFF
--- a/src/app/main/main-window/sidebar/sidebar.component.scss
+++ b/src/app/main/main-window/sidebar/sidebar.component.scss
@@ -190,8 +190,7 @@ $img-border-color: rgba(255, 255, 255, 0.1);
 
       .sidebar-dropdown {
         > a:after {
-          font-family: 'Font Awesome 5 Free', serif;
-          font-weight: 900;
+          font: var(--fa-font-solid);
           content: '\f105';
           display: inline-block;
           font-style: normal;


### PR DESCRIPTION
Closes https://github.com/azerothcore/Keira3/issues/1695  

It seems that Font Awesome was upgraded from v5 to v6. Version 6 introduced breaking changes on how to use the icons with pseudo-elements. You can find the changes under [this link](https://fontawesome.com/docs/web/setup/upgrade/pseudo-elements), especially the paragraph "Updating Font Rule Syntax". Normally there should be an automated backward compatibility feature, but it seems this didn't work here.

The result after the changes is the following:
![image](https://user-images.githubusercontent.com/10009755/166078792-c9daf362-3ed1-495e-9dea-ab3d189c4a0e.png)
