### PR TITLE
fix: SAI phase comment calculation, closes #2080

### DIFF
--- a/src/app/shared/modules/sai-editor/sai-comment-generator.service.spec.ts
+++ b/src/app/shared/modules/sai-editor/sai-comment-generator.service.spec.ts
@@ -49,20 +49,17 @@ describe('SaiCommentGeneratorService', () => {
       spyOn(sqliteQueryService, 'getSpellNameById').and.callFake((i) => of(mockGetSpellNameById + i).toPromise());
     });
 
-    it(
-      'should correctly handle linked events',
-      waitForAsync(async () => {
-        const rows: SmartScripts[] = [
-          createSai({ id: 1, event_type: SAI_EVENTS.ACCEPTED_QUEST, link: 2 }),
-          createSai({ id: 2, event_type: SAI_EVENTS.LINK, link: 3 }),
-          createSai({ id: 3, event_type: SAI_EVENTS.LINK }),
-        ];
-        const expected = `MockEntity - On Quest 'mockQuestTitleById0' Taken - No Action Type`;
-        const service: SaiCommentGeneratorService = TestBed.inject(SaiCommentGeneratorService);
+    it('should correctly handle linked events', waitForAsync(async () => {
+      const rows: SmartScripts[] = [
+        createSai({ id: 1, event_type: SAI_EVENTS.ACCEPTED_QUEST, link: 2 }),
+        createSai({ id: 2, event_type: SAI_EVENTS.LINK, link: 3 }),
+        createSai({ id: 3, event_type: SAI_EVENTS.LINK }),
+      ];
+      const expected = `MockEntity - On Quest 'mockQuestTitleById0' Taken - No Action Type`;
+      const service: SaiCommentGeneratorService = TestBed.inject(SaiCommentGeneratorService);
 
-        expect(await service.generateComment(rows, rows[2], mockName)).toEqual(expected);
-      }),
-    );
+      expect(await service.generateComment(rows, rows[2], mockName)).toEqual(expected);
+    }));
 
     const cases: { name: string; input: Partial<SmartScripts>; expected: string }[] = [
       {
@@ -1641,7 +1638,7 @@ describe('SaiCommentGeneratorService', () => {
           event_phase_mask: 9,
           event_flags: EVENT_FLAGS.NOT_REPEATABLE,
         },
-        expected: `MockEntity - In Combat - Mount To Model 1 (Phases 1 & 8) (No Repeat)`,
+        expected: `MockEntity - In Combat - Mount To Model 1 (Phases 1 & 4) (No Repeat)`,
       },
       {
         name: `SAI_ACTIONS.MOUNT_TO_ENTRY_OR_MODEL check action param 2 (1), event_phase_mask (2)`,
@@ -1753,14 +1750,11 @@ describe('SaiCommentGeneratorService', () => {
     ];
 
     for (const { name, input, expected } of cases) {
-      it(
-        `Case: ${name}`,
-        waitForAsync(async () => {
-          const service: SaiCommentGeneratorService = TestBed.inject(SaiCommentGeneratorService);
-          const sai = createSai(input);
-          expect(await service.generateComment([sai], sai, mockName)).toEqual(expected);
-        }),
-      );
+      it(`Case: ${name}`, waitForAsync(async () => {
+        const service: SaiCommentGeneratorService = TestBed.inject(SaiCommentGeneratorService);
+        const sai = createSai(input);
+        expect(await service.generateComment([sai], sai, mockName)).toEqual(expected);
+      }));
     }
   });
 });

--- a/src/app/shared/modules/sai-editor/sai-comment-generator.service.ts
+++ b/src/app/shared/modules/sai-editor/sai-comment-generator.service.ts
@@ -836,7 +836,8 @@ export class SaiCommentGeneratorService {
 
         if (event_phase_mask >= power) {
           event_phase_mask -= power;
-          arrayOfSplitPhases.push(power);
+          const smart_event_phase = Math.floor(Math.log(power) / Math.log(2)) + 1;
+          arrayOfSplitPhases.push(smart_event_phase);
         }
       }
 


### PR DESCRIPTION
closes https://github.com/azerothcore/Keira3/issues/2080
given a creature SAI with the following phase, the generated comment is wrong

![image](https://user-images.githubusercontent.com/519778/211226024-e46701e5-c0e8-4fca-8381-d8d55f7e3929.png)

current generated comment: `Phases 1 & 2 & 8 & 256`
expected comment: `phases 1 & 2 & 4 & 9`