### PR TITLE
feat. update workflows macOS

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18]
-        os: [macos-10.15]
+        os: [macos-12]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}-node-${{ matrix.node-version }}
 


### PR DESCRIPTION
The macOS 10.15 Actions runner image [started our deprecation process](https://github.com/actions/virtual-environments/issues/5583) on 5/31/22 and will be fully unsupported by 8/30/22. To raise awareness of the upcoming removal, jobs using macOS 10.15 will temporarily fail during scheduled time periods defined below:

- July 21, 12:00 UTC – July 22, 18:00 UTC
- July 27, 00:00 UTC – July 28, 00:00 UTC
- August 3, 00:00 UTC – August 4, 00:00 UTC
- August 15, 00:00 UTC – August 16, 00:00 UTC
- August 26, 00:00 UTC – August 27, 00:00 UTC

## What you need to do

Workflows using the macos-10.15 YAML workflow label should be updated to macos-11, macos-12, or macos-latest. You can always get up-to-date information on our tools by reading about the [software](https://github.com/actions/virtual-environments) in GitHub Actions virtual environments. Please contact GitHub [Support](https://support.github.com/contact?form%5Bsubject%5D=Re%3A+GitHub+Actions&tags=dotcom-contact-params) if you run into any problems or need help.

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/#:~:text=The%20macOS%2010.15%20Actions%20runner%20image%20started%20our%20deprecation%20process,July%2022%2C%2018%3A00%20UTC