### PR TITLE
Remove aur package

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ Alternatively, you can use a public database of AzerothCore with read-only acces
 
 To use Keira3, you don't need to install any dependency. Just [download](https://github.com/azerothcore/Keira3/releases) and run it.
 
-If you are using Arch Linux you can find the package on [AUR](https://aur.archlinux.org/packages/keira3/)
-
 :warning: [Windows 7 or older Windows versions](https://github.com/azerothcore/Keira3/issues/2212) are not officially supported.
 
 ## How to run Keira3 in development mode


### PR DESCRIPTION
Hello everyone, long time no see,

As i don't have time to maintain the AUR package and a mac user from some time, the aur package got out of my hands, currently it got moved to https://aur.archlinux.org/account/muflone/ who instead of maintaining or keeping the AUR package active, removed it.

So, the removal of the AUR reference is needed as it is not valid anymore.