### PR TITLE
chore(Creature): improved several tooltips

### DIFF
--- a/apps/keira/src/assets/i18n/de.json
+++ b/apps/keira/src/assets/i18n/de.json
@@ -241,7 +241,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/de.json
+++ b/apps/keira/src/assets/i18n/de.json
@@ -227,7 +227,7 @@
       "SKINLOOT": "Link to skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/de.json
+++ b/apps/keira/src/assets/i18n/de.json
@@ -283,6 +283,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/de.json
+++ b/apps/keira/src/assets/i18n/de.json
@@ -283,9 +283,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/de.json
+++ b/apps/keira/src/assets/i18n/de.json
@@ -242,9 +242,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/el.json
+++ b/apps/keira/src/assets/i18n/el.json
@@ -241,7 +241,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/el.json
+++ b/apps/keira/src/assets/i18n/el.json
@@ -227,7 +227,7 @@
       "SKINLOOT": "Link to skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/el.json
+++ b/apps/keira/src/assets/i18n/el.json
@@ -283,6 +283,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/el.json
+++ b/apps/keira/src/assets/i18n/el.json
@@ -283,9 +283,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/el.json
+++ b/apps/keira/src/assets/i18n/el.json
@@ -242,9 +242,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/en.json
+++ b/apps/keira/src/assets/i18n/en.json
@@ -284,7 +284,7 @@
       "INDEX": "Allowed values: 0-7"
     },
     "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3- SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
     },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",

--- a/apps/keira/src/assets/i18n/en.json
+++ b/apps/keira/src/assets/i18n/en.json
@@ -241,7 +241,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/en.json
+++ b/apps/keira/src/assets/i18n/en.json
@@ -227,7 +227,7 @@
       "SKINLOOT": "Link to skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/en.json
+++ b/apps/keira/src/assets/i18n/en.json
@@ -283,6 +283,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3- SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/en.json
+++ b/apps/keira/src/assets/i18n/en.json
@@ -283,9 +283,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/en.json
+++ b/apps/keira/src/assets/i18n/en.json
@@ -242,9 +242,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/es.json
+++ b/apps/keira/src/assets/i18n/es.json
@@ -284,6 +284,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Valores permitidos: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "El coste a pagar para poder aprender el Hechizo, representado en monedas de cobre (1 de oro = 100 de plata = 10000 de cobre)",
       "REQ_SKILL_LINE": "La Habilidad requerida que debe tener previamente el jugador para poder aprender el Hechizo.",

--- a/apps/keira/src/assets/i18n/es.json
+++ b/apps/keira/src/assets/i18n/es.json
@@ -242,7 +242,10 @@
       "SPEED_WALK": "Controla la velocidad promedio a la que puede caminar la criatura. En el caso de los vehículos, aumenta la velocidad de movimiento por tierra.",
       "SPEED_SWIM": "Controla la velocidad promedio a la que puede nadar la criatura.",
       "SPEED_FLIGHT": "Controla la velocidad promedio a la que puede volar la criatura.",
-      "DETECTION_RANGE": "Controla el rango en el que las criaturas detectan y ven a los jugadores."
+      "DETECTION_RANGE": "Controla el rango en el que las criaturas detectan y ven a los jugadores.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Enlazado con creature_template.entry (ID de la Criatura)",

--- a/apps/keira/src/assets/i18n/es.json
+++ b/apps/keira/src/assets/i18n/es.json
@@ -243,9 +243,9 @@
       "SPEED_SWIM": "Controla la velocidad promedio a la que puede nadar la criatura.",
       "SPEED_FLIGHT": "Controla la velocidad promedio a la que puede volar la criatura.",
       "DETECTION_RANGE": "Controla el rango en el que las criaturas detectan y ven a los jugadores.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Enlazado con creature_template.entry (ID de la Criatura)",

--- a/apps/keira/src/assets/i18n/es.json
+++ b/apps/keira/src/assets/i18n/es.json
@@ -284,9 +284,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Valores permitidos: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "El coste a pagar para poder aprender el Hechizo, representado en monedas de cobre (1 de oro = 100 de plata = 10000 de cobre)",
       "REQ_SKILL_LINE": "La Habilidad requerida que debe tener previamente el jugador para poder aprender el Hechizo.",

--- a/apps/keira/src/assets/i18n/es.json
+++ b/apps/keira/src/assets/i18n/es.json
@@ -228,7 +228,7 @@
       "SKINLOOT": "Enlazado con skinning_loot_template.entry (Botín de Desuello)",
       "DIFFICULTY_ENTRY_1": "Entrada (ID) de la criatura equivalente a Mazmorra Heroica o Raid Normal de 25 jugadores",
       "DIFFICULTY_ENTRY_2": "Entrada (ID) de la criatura equivalente a Raid Heróica de 10 jugadores",
-      "difficulty_entry_3": "Entrada (ID) de la criatura equivalente a Raid Heróica de 25 jugadores",
+      "DIFFICULTY_ENTRY_3": "Entrada (ID) de la criatura equivalente a Raid Heróica de 25 jugadores",
       "BASE_ATTACK_TIME": "Tiempo base (en millisegundos) que determina cuánto tiempo debe esperar una criatura entre ataques cuerpo a cuerpo.",
       "RANGE_ATTACK_TIME": "Tiempo base (en millisegundos) que determina cuánto tiempo debe esperar una criatura entre ataques a distancia.",
       "SCRIPT_NAME": "Anula AIName. El nombre del script escrito en C++ que utiliza esta criatura en particular, si existe, claro está.",

--- a/apps/keira/src/assets/i18n/fr.json
+++ b/apps/keira/src/assets/i18n/fr.json
@@ -238,9 +238,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/fr.json
+++ b/apps/keira/src/assets/i18n/fr.json
@@ -279,6 +279,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/fr.json
+++ b/apps/keira/src/assets/i18n/fr.json
@@ -279,9 +279,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/fr.json
+++ b/apps/keira/src/assets/i18n/fr.json
@@ -237,7 +237,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/fr.json
+++ b/apps/keira/src/assets/i18n/fr.json
@@ -223,7 +223,7 @@
       "SKINLOOT": "Link to skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/it.json
+++ b/apps/keira/src/assets/i18n/it.json
@@ -226,7 +226,7 @@
       "SKINLOOT": "Link to skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/it.json
+++ b/apps/keira/src/assets/i18n/it.json
@@ -240,7 +240,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/it.json
+++ b/apps/keira/src/assets/i18n/it.json
@@ -282,6 +282,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/it.json
+++ b/apps/keira/src/assets/i18n/it.json
@@ -282,9 +282,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/it.json
+++ b/apps/keira/src/assets/i18n/it.json
@@ -241,9 +241,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/ko.json
+++ b/apps/keira/src/assets/i18n/ko.json
@@ -241,7 +241,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/ko.json
+++ b/apps/keira/src/assets/i18n/ko.json
@@ -227,7 +227,7 @@
       "SKINLOOT": "Link to skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/ko.json
+++ b/apps/keira/src/assets/i18n/ko.json
@@ -283,6 +283,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/ko.json
+++ b/apps/keira/src/assets/i18n/ko.json
@@ -283,9 +283,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/ko.json
+++ b/apps/keira/src/assets/i18n/ko.json
@@ -242,9 +242,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/nl.json
+++ b/apps/keira/src/assets/i18n/nl.json
@@ -241,7 +241,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/nl.json
+++ b/apps/keira/src/assets/i18n/nl.json
@@ -227,7 +227,7 @@
       "SKINLOOT": "Link to skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/nl.json
+++ b/apps/keira/src/assets/i18n/nl.json
@@ -283,6 +283,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/nl.json
+++ b/apps/keira/src/assets/i18n/nl.json
@@ -283,9 +283,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/nl.json
+++ b/apps/keira/src/assets/i18n/nl.json
@@ -242,9 +242,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/pl.json
+++ b/apps/keira/src/assets/i18n/pl.json
@@ -241,7 +241,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/pl.json
+++ b/apps/keira/src/assets/i18n/pl.json
@@ -227,7 +227,7 @@
       "SKINLOOT": "Link to skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/pl.json
+++ b/apps/keira/src/assets/i18n/pl.json
@@ -283,6 +283,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/pl.json
+++ b/apps/keira/src/assets/i18n/pl.json
@@ -283,9 +283,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/pl.json
+++ b/apps/keira/src/assets/i18n/pl.json
@@ -242,9 +242,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/pt.json
+++ b/apps/keira/src/assets/i18n/pt.json
@@ -237,7 +237,10 @@
       "SPEED_WALK": "Controla quão rápido a creature pode correr. Para veículos, aumenta a velocidade terrestre.",
       "SPEED_SWIM": "Controla quão rápido a creature pode nadar.",
       "SPEED_FLIGHT": "Controla quão rápido a creature pode voar.",
-      "DETECTION_RANGE": "Controla o alcance do qual a creature pode detectar e ver jogadores."
+      "DETECTION_RANGE": "Controla o alcance do qual a creature pode detectar e ver jogadores.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link para creature_template.entry",

--- a/apps/keira/src/assets/i18n/pt.json
+++ b/apps/keira/src/assets/i18n/pt.json
@@ -238,9 +238,9 @@
       "SPEED_SWIM": "Controla quão rápido a creature pode nadar.",
       "SPEED_FLIGHT": "Controla quão rápido a creature pode voar.",
       "DETECTION_RANGE": "Controla o alcance do qual a creature pode detectar e ver jogadores.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link para creature_template.entry",

--- a/apps/keira/src/assets/i18n/pt.json
+++ b/apps/keira/src/assets/i18n/pt.json
@@ -223,7 +223,7 @@
       "SKINLOOT": "Link para skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry da creature equivalente em uma Heroic Dungeon ou uma Raid Normal 25man",
       "DIFFICULTY_ENTRY_2": "Entry da creature equivalente em uma Raid Heroic 10man",
-      "difficulty_entry_3": "Entry da creature equivalente em uma Raid Heroic 25man",
+      "DIFFICULTY_ENTRY_3": "Entry da creature equivalente em uma Raid Heroic 25man",
       "BASE_ATTACK_TIME": "Tempo base (milisegundos) que determina quanto tempo que a creature deve esperar entre ataques corpo à corpo.",
       "RANGE_ATTACK_TIME": "Tempo base (milisegundos) que determina quanto tempo que a creature deve esperar entre ataques à distância.",
       "SCRIPT_NAME": "Sobrepõe AIName. É o nome do script C++ que essa creature usa, caso exista.",

--- a/apps/keira/src/assets/i18n/pt.json
+++ b/apps/keira/src/assets/i18n/pt.json
@@ -279,6 +279,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Valores permitidos: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "O preço para aprender o spell, representado em copper (1 gold = 100 silver = 10000 copper)",
       "REQ_SKILL_LINE": "O skill necessário para o jogador aprender o spell",

--- a/apps/keira/src/assets/i18n/pt.json
+++ b/apps/keira/src/assets/i18n/pt.json
@@ -279,9 +279,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Valores permitidos: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "O preço para aprender o spell, representado em copper (1 gold = 100 silver = 10000 copper)",
       "REQ_SKILL_LINE": "O skill necessário para o jogador aprender o spell",

--- a/apps/keira/src/assets/i18n/ro.json
+++ b/apps/keira/src/assets/i18n/ro.json
@@ -241,7 +241,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/ro.json
+++ b/apps/keira/src/assets/i18n/ro.json
@@ -227,7 +227,7 @@
       "SKINLOOT": "Link to skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/ro.json
+++ b/apps/keira/src/assets/i18n/ro.json
@@ -283,6 +283,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/ro.json
+++ b/apps/keira/src/assets/i18n/ro.json
@@ -283,9 +283,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/ro.json
+++ b/apps/keira/src/assets/i18n/ro.json
@@ -242,9 +242,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/ru.json
+++ b/apps/keira/src/assets/i18n/ru.json
@@ -279,6 +279,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/ru.json
+++ b/apps/keira/src/assets/i18n/ru.json
@@ -279,9 +279,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/ru.json
+++ b/apps/keira/src/assets/i18n/ru.json
@@ -238,9 +238,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Ссылка на creature_template.entry",

--- a/apps/keira/src/assets/i18n/ru.json
+++ b/apps/keira/src/assets/i18n/ru.json
@@ -237,7 +237,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Ссылка на creature_template.entry",

--- a/apps/keira/src/assets/i18n/ru.json
+++ b/apps/keira/src/assets/i18n/ru.json
@@ -223,7 +223,7 @@
       "SKINLOOT": "Ссылка на skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry эквивалентного существа в Героическом подземелье или Обычный рейд на 25 человек",
       "DIFFICULTY_ENTRY_2": "Entry эквивалентного существа в Героическом рейде на 10 человек",
-      "difficulty_entry_3": "Entry эквивалентного существа в Героическом рейде на 25 человек",
+      "DIFFICULTY_ENTRY_3": "Entry эквивалентного существа в Героическом рейде на 25 человек",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/sk.json
+++ b/apps/keira/src/assets/i18n/sk.json
@@ -241,7 +241,10 @@
       "SPEED_WALK": "Controls how fast the creature can run. For vehicles it increases ground movement speed.",
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
-      "DETECTION_RANGE": "Controls the range at which creatures detect and see players."
+      "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/sk.json
+++ b/apps/keira/src/assets/i18n/sk.json
@@ -227,7 +227,7 @@
       "SKINLOOT": "Link to skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between melee attacks.",
       "RANGE_ATTACK_TIME": "Base time (milliseconds) that determines how long a creature must wait between ranged attacks.",
       "SCRIPT_NAME": "Overrides AIName. The name of the C++ script that this creature uses, if any.",

--- a/apps/keira/src/assets/i18n/sk.json
+++ b/apps/keira/src/assets/i18n/sk.json
@@ -283,6 +283,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/sk.json
+++ b/apps/keira/src/assets/i18n/sk.json
@@ -283,9 +283,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "The cost to pay to learn the spell represented in copper (1 gold = 100 silver = 10000 cooper)",
       "REQ_SKILL_LINE": "The required skill the player needs to have in order to be able to learn the spell",

--- a/apps/keira/src/assets/i18n/sk.json
+++ b/apps/keira/src/assets/i18n/sk.json
@@ -242,9 +242,9 @@
       "SPEED_SWIM": "Controls how fast the creature can swim.",
       "SPEED_FLIGHT": "Controls how fast the creature can fly.",
       "DETECTION_RANGE": "Controls the range at which creatures detect and see players.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Link to creature_template.entry",

--- a/apps/keira/src/assets/i18n/sv.json
+++ b/apps/keira/src/assets/i18n/sv.json
@@ -237,7 +237,10 @@
       "SPEED_WALK": "Kontrollerar hur snabbt en NPC kan springa. För fordon blir det snabbare på marken.",
       "SPEED_SWIM": "Kontrollerar hur snabbt en NPC kan simma.",
       "SPEED_FLIGHT": "Kontrollerar hur snabbt en NPC kan flyga.",
-      "DETECTION_RANGE": "Kontrollerar hur nära eller långt ifrån en NPC kan upptäcka spelare."
+      "DETECTION_RANGE": "Kontrollerar hur nära eller långt ifrån en NPC kan upptäcka spelare.",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Länk till creature_template.entry",

--- a/apps/keira/src/assets/i18n/sv.json
+++ b/apps/keira/src/assets/i18n/sv.json
@@ -223,7 +223,7 @@
       "SKINLOOT": "Länk till skinning_loot_template.entry",
       "DIFFICULTY_ENTRY_1": "Entry of the equivalent creature in Heroic Dungeon or 25man Normal Raid",
       "DIFFICULTY_ENTRY_2": "Entry of the equivalent creature in 10man Heroic Raid",
-      "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",
+      "DIFFICULTY_ENTRY_3": "Entry of the equivalent creature in 25man Heroic Raid",
       "BASE_ATTACK_TIME": "Bastid (millisekunder) som avgör hur länge en NPC måste vänta mellan sina Melee Attacker.",
       "RANGE_ATTACK_TIME": "Bastid (millisekunder) som avgör hur länge en NPC måste vänta mellan sina Range Attacker.",
       "SCRIPT_NAME": "Åsidosätter AIName. Namnet utav C++ script som denna NPC använder, om det finns något.",

--- a/apps/keira/src/assets/i18n/sv.json
+++ b/apps/keira/src/assets/i18n/sv.json
@@ -279,6 +279,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "Vad det kommer att kosta att lära sig en Spell i coppar (1 gold = 100 silver = 10000 copper)",
       "REQ_SKILL_LINE": "Vilken Spell som behövs för att spelaren ska kunna lära sig denna Spell",

--- a/apps/keira/src/assets/i18n/sv.json
+++ b/apps/keira/src/assets/i18n/sv.json
@@ -279,9 +279,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "Allowed values: 0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "Vad det kommer att kosta att lära sig en Spell i coppar (1 gold = 100 silver = 10000 copper)",
       "REQ_SKILL_LINE": "Vilken Spell som behövs för att spelaren ska kunna lära sig denna Spell",

--- a/apps/keira/src/assets/i18n/sv.json
+++ b/apps/keira/src/assets/i18n/sv.json
@@ -238,9 +238,9 @@
       "SPEED_SWIM": "Kontrollerar hur snabbt en NPC kan simma.",
       "SPEED_FLIGHT": "Kontrollerar hur snabbt en NPC kan flyga.",
       "DETECTION_RANGE": "Kontrollerar hur nära eller långt ifrån en NPC kan upptäcka spelare.",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "Länk till creature_template.entry",

--- a/apps/keira/src/assets/i18n/zh.json
+++ b/apps/keira/src/assets/i18n/zh.json
@@ -277,6 +277,9 @@
     "TEMPLATE_SPELL": {
       "INDEX": "范围值：0-7"
     },
+    "TEMPLATE_RESISTANCE": {
+      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
+    },
     "NPC_TRAINER": {
       "MONEY_COST": "学习该法术的金钱，用铜币表示(1金=100银=10000铜)",
       "REQ_SKILL_LINE": "玩家学习技能所需的前置技能",

--- a/apps/keira/src/assets/i18n/zh.json
+++ b/apps/keira/src/assets/i18n/zh.json
@@ -237,9 +237,9 @@
       "SPEED_SWIM": "控制生物游泳的速度。",
       "SPEED_FLIGHT": "控制生物的飞行速度。",
       "DETECTION_RANGE": "控制生物感知到玩家靠近的范围。",
-      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
-      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
-      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
+      "ITEMID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ITEMID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ITEMID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "链接至creature_template表的entry字段",

--- a/apps/keira/src/assets/i18n/zh.json
+++ b/apps/keira/src/assets/i18n/zh.json
@@ -223,7 +223,7 @@
       "SKINLOOT": "skinning_loot_template表中的entry字段",
       "DIFFICULTY_ENTRY_1": "在25人英雄副本和普通副本中使用相同的生物",
       "DIFFICULTY_ENTRY_2": "在10人英雄副本中使用相同的生物",
-      "difficulty_entry_3": "在25人英雄副本中使用相同的生物",
+      "DIFFICULTY_ENTRY_3": "在25人英雄副本中使用相同的生物",
       "BASE_ATTACK_TIME": "近战攻击间隔时间(单位：毫秒)。",
       "RANGE_ATTACK_TIME": "远程攻击间隔时间(单位：毫秒)。",
       "SCRIPT_NAME": "覆盖AIName。此生物使用独立的C++脚本在这里输入脚本名称。",

--- a/apps/keira/src/assets/i18n/zh.json
+++ b/apps/keira/src/assets/i18n/zh.json
@@ -236,7 +236,10 @@
       "SPEED_WALK": "控制生物的奔跑速度。对于陆地载具来说，提高地面移动速度。",
       "SPEED_SWIM": "控制生物游泳的速度。",
       "SPEED_FLIGHT": "控制生物的飞行速度。",
-      "DETECTION_RANGE": "控制生物感知到玩家靠近的范围。"
+      "DETECTION_RANGE": "控制生物感知到玩家靠近的范围。",
+      "ItemID1": "This is the item number of the equipment used in the right hand from Item.dbc.",
+      "ItemID2": "This is the item number of the equipment used in the left hand from Item.dbc.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc."
     },
     "TEMPLATE_ADDON": {
       "ENTRY": "链接至creature_template表的entry字段",

--- a/apps/keira/src/assets/i18n/zh.json
+++ b/apps/keira/src/assets/i18n/zh.json
@@ -277,9 +277,6 @@
     "TEMPLATE_SPELL": {
       "INDEX": "范围值：0-7"
     },
-    "TEMPLATE_RESISTANCE": {
-      "SCHOOL": "1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE"
-    },
     "NPC_TRAINER": {
       "MONEY_COST": "学习该法术的金钱，用铜币表示(1金=100银=10000铜)",
       "REQ_SKILL_LINE": "玩家学习技能所需的前置技能",

--- a/libs/features/creature/src/creature-equip-template/creature-equip-template.component.html
+++ b/libs/features/creature/src/creature-equip-template/creature-equip-template.component.html
@@ -15,6 +15,7 @@
           <div class="row">
             <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
               <label class="control-label" for="CreatureID">CreatureID</label>
+              <i class="fas fa-info-circle ms-1" placement="auto" [tooltip]="'UNIQUE_ID' | translate: { ENTITY: 'creature' }"></i>
               <input [formControlName]="'CreatureID'" id="CreatureID" type="number" class="form-control form-control-sm" />
             </div>
             <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
@@ -22,6 +23,7 @@
                 <keira-icon [itemId]="editorService.form.controls.ItemID1.value" />
                 ItemID1
               </label>
+              <i class="fas fa-info-circle ms-1" placement="auto" [tooltip]="'CREATURE.TEMPLATE.ITEMID1' | translate"></i>
               <keira-item-selector-btn
                 [control]="editorService.form.controls.ItemID1"
                 [disabled]="editorService.form.controls.ItemID1.disabled"
@@ -34,6 +36,7 @@
                 <keira-icon [itemId]="editorService.form.controls.ItemID2.value" />
                 ItemID2
               </label>
+              <i class="fas fa-info-circle ms-1" placement="auto" [tooltip]="'CREATURE.TEMPLATE.ITEMID2' | translate"></i>
               <keira-item-selector-btn
                 [control]="editorService.form.controls.ItemID2"
                 [disabled]="editorService.form.controls.ItemID2.disabled"
@@ -46,6 +49,7 @@
                 <keira-icon [itemId]="editorService.form.controls.ItemID3.value" />
                 ItemID3
               </label>
+              <i class="fas fa-info-circle ms-1" placement="auto" [tooltip]="'CREATURE.TEMPLATE.ITEMID3' | translate"></i>
               <keira-item-selector-btn
                 [control]="editorService.form.controls.ItemID3"
                 [disabled]="editorService.form.controls.ItemID3.disabled"

--- a/libs/features/creature/src/creature-equip-template/creature-equip-template.component.ts
+++ b/libs/features/creature/src/creature-equip-template/creature-equip-template.component.ts
@@ -7,6 +7,7 @@ import { ItemSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateModule } from '@ngx-translate/core';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureEquipTemplateService } from './creature-equip-template.service';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -22,6 +23,7 @@ import { CreatureEquipTemplateService } from './creature-equip-template.service'
     ReactiveFormsModule,
     IconComponent,
     ItemSelectorBtnComponent,
+    TooltipModule,
   ],
 })
 export class CreatureEquipTemplateComponent extends SingleRowEditorComponent<CreatureEquipTemplate> {

--- a/libs/features/creature/src/creature-onkill-reputation/creature-onkill-reputation.component.html
+++ b/libs/features/creature/src/creature-onkill-reputation/creature-onkill-reputation.component.html
@@ -15,6 +15,7 @@
           <div class="row">
             <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
               <label class="control-label" for="creature_id">creature_id</label>
+              <i class="fas fa-info-circle ms-1" placement="auto" [tooltip]="'UNIQUE_ID' | translate: { ENTITY: 'creature' }"></i>
               <input [formControlName]="'creature_id'" id="creature_id" type="number" class="form-control form-control-sm" />
             </div>
             <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">

--- a/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.html
+++ b/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.html
@@ -15,7 +15,6 @@
           <div class="row">
             <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
               <label class="control-label" for="School">School</label>
-              <i class="fas fa-info-circle ms-1" placement="auto" [tooltip]="'CREATURE.TEMPLATE_RESISTANCE.SCHOOL' | translate"></i>
               <keira-generic-option-selector
                 [control]="editorService.form.controls.School"
                 id="School"

--- a/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.html
+++ b/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.html
@@ -15,6 +15,7 @@
           <div class="row">
             <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
               <label class="control-label" for="School">School</label>
+              <i class="fas fa-info-circle ms-1" placement="auto" [tooltip]="'CREATURE.TEMPLATE_RESISTANCE.SCHOOL' | translate"></i>
               <keira-generic-option-selector
                 [control]="editorService.form.controls.School"
                 id="School"

--- a/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.ts
+++ b/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.ts
@@ -12,6 +12,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTemplateResistanceService } from './creature-template-resistance.service';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -28,6 +29,7 @@ import { CreatureTemplateResistanceService } from './creature-template-resistanc
     EditorButtonsComponent,
     NgxDatatableModule,
     GenericOptionSelectorComponent,
+    TooltipModule,
   ],
 })
 export class CreatureTemplateResistanceComponent extends MultiRowEditorComponent<CreatureTemplateResistance> {


### PR DESCRIPTION
## `apps\keira\src\assets\i18n` - Changes (to all languages)

### CREATURE.TEMPLATE
In: "difficulty_entry_3": "Entry of the equivalent creature in 25man Heroic Raid",

Corrected `difficulty_entry_3` to `DIFFICULTY_ENTRY_3` to match the others.

Created: 
`ITEMID1`: "This is the item number of the equipment used in the right hand from Item.dbc.",
`ITEMID2`: "This is the item number of the equipment used in the left hand from Item.dbc.",
`ITEMID3`: "This is the item number of the equipment used in the ranged slot from Item.dbc."

### ~CREATURE.TEMPLATE_RESISTANCE~

~Created:~

~TEMPLATE_RESISTANCE.SCHOOL: `1 - SPELL_SCHOOL_HOLY; 2 - SPELL_SCHOOL_FIRE; 3 - SPELL_SCHOOL_NATURE; 4 - SPELL_SCHOOL_FROST; 5 - SPELL_SCHOOL_SHADOW; 6 - SPELL_SCHOOL_ARCANE`~

## `libs\features\creature\src` - Changes (Equip, OnKill-Rep and Resistance)

### creature_equip_template

Added `[tooltip]="'UNIQUE_ID' | translate: { ENTITY: 'creature' }` to creatureID to match the others Infos for the CreatureID

Created: 
`[tooltip]="'CREATURE.TEMPLATE.ITEMID1' | translate`
`[tooltip]="'CREATURE.TEMPLATE.ITEMID2' | translate`
`[tooltip]="'CREATURE.TEMPLATE.ITEMID3' | translate`

For each respective itemID.


### creature_onkill_reputation

Added `[tooltip]="'UNIQUE_ID' | translate: { ENTITY: 'creature' }` to creatureID to match the others Infos for the CreatureID

### ~creature_template_resistance~

~Created:~

~`[tooltip]="'CREATURE.TEMPLATE_RESISTANCE.SCHOOL' | translate`~

---

Resovles: https://github.com/azerothcore/Keira3/issues/3122