### PR TITLE
Convert editorService from public to protected

### DIFF
--- a/libs/features/creature/src/creature-equip-template/creature-equip-template.component.ts
+++ b/libs/features/creature/src/creature-equip-template/creature-equip-template.component.ts
@@ -27,6 +27,6 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
   ],
 })
 export class CreatureEquipTemplateComponent extends SingleRowEditorComponent<CreatureEquipTemplate> {
-  override readonly editorService = inject(CreatureEquipTemplateService);
+  protected override readonly editorService = inject(CreatureEquipTemplateService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/creature-loot-template/creature-loot-template.component.ts
+++ b/libs/features/creature/src/creature-loot-template/creature-loot-template.component.ts
@@ -14,6 +14,6 @@ import { CreatureLootTemplateService } from './creature-loot-template.service';
   imports: [TopBarComponent, LootEditorComponent],
 })
 export class CreatureLootTemplateComponent extends LootTemplateIdComponent<CreatureLootTemplate> {
-  override readonly editorService = inject(CreatureLootTemplateService);
+  protected override readonly editorService = inject(CreatureLootTemplateService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/creature-onkill-reputation/creature-onkill-reputation.component.ts
+++ b/libs/features/creature/src/creature-onkill-reputation/creature-onkill-reputation.component.ts
@@ -36,6 +36,6 @@ import { CreatureOnkillReputationService } from './creature-onkill-reputation.se
 export class CreatureOnkillReputationComponent extends SingleRowEditorComponent<CreatureOnkillReputation> {
   readonly FACTION_RANK = FACTION_RANK;
 
-  override readonly editorService = inject(CreatureOnkillReputationService);
+  protected override readonly editorService = inject(CreatureOnkillReputationService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/creature-questitem/creature-questitem.component.ts
+++ b/libs/features/creature/src/creature-questitem/creature-questitem.component.ts
@@ -30,6 +30,6 @@ import { CreatureQuestitemService } from './creature-questitem.service';
   ],
 })
 export class CreatureQuestitemComponent extends MultiRowEditorComponent<CreatureQuestitem> {
-  override readonly editorService = inject(CreatureQuestitemService);
+  protected override readonly editorService = inject(CreatureQuestitemService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/creature-spawn-addon/creature-spawn-addon.component.ts
+++ b/libs/features/creature/src/creature-spawn-addon/creature-spawn-addon.component.ts
@@ -33,6 +33,6 @@ export class CreatureSpawnAddonComponent extends MultiRowEditorComponent<Creatur
   readonly CREATURE_ADDON_BYTES_1 = CREATURE_ADDON_BYTES_1;
   readonly CREATURE_ADDON_BYTES_2 = CREATURE_ADDON_BYTES_2;
 
-  override readonly editorService = inject(CreatureSpawnAddonService);
+  protected override readonly editorService = inject(CreatureSpawnAddonService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/creature-spawn/creature-spawn.component.ts
+++ b/libs/features/creature/src/creature-spawn/creature-spawn.component.ts
@@ -54,6 +54,6 @@ export class CreatureSpawnComponent extends MultiRowEditorComponent<CreatureSpaw
   readonly SPAWN_MASK = SPAWN_MASK;
   readonly PHASE_MASK = PHASE_MASK;
 
-  override readonly editorService = inject(CreatureSpawnService);
+  protected override readonly editorService = inject(CreatureSpawnService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/creature-template-addon/creature-template-addon.component.ts
+++ b/libs/features/creature/src/creature-template-addon/creature-template-addon.component.ts
@@ -40,6 +40,6 @@ export class CreatureTemplateAddonComponent extends SingleRowEditorComponent<Cre
   protected readonly CREATURE_ADDON_BYTES_1 = CREATURE_ADDON_BYTES_1;
   protected readonly CREATURE_ADDON_BYTES_2 = CREATURE_ADDON_BYTES_2;
 
-  override readonly editorService = inject(CreatureTemplateAddonService);
+  protected override readonly editorService = inject(CreatureTemplateAddonService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/creature-template-model/creature-template-model.component.ts
+++ b/libs/features/creature/src/creature-template-model/creature-template-model.component.ts
@@ -32,7 +32,7 @@ import { CreatureTemplateModelService } from './creature-template-model.service'
   ],
 })
 export class CreatureTemplateModelComponent extends MultiRowEditorComponent<CreatureTemplateModel> {
-  override readonly editorService = inject(CreatureTemplateModelService);
+  protected override readonly editorService = inject(CreatureTemplateModelService);
   readonly handlerService = inject(CreatureHandlerService);
 
   protected readonly NPC_VIEWER_TYPE = VIEWER_TYPE.NPC;

--- a/libs/features/creature/src/creature-template-movement/creature-template-movement.component.ts
+++ b/libs/features/creature/src/creature-template-movement/creature-template-movement.component.ts
@@ -20,6 +20,6 @@ export class CreatureTemplateMovementComponent extends SingleRowEditorComponent<
     return this.WIKI_BASE_URL + CREATURE_TEMPLATE_MOVEMENT_TABLE;
   }
 
-  override readonly editorService = inject(CreatureTemplateMovementService);
+  protected override readonly editorService = inject(CreatureTemplateMovementService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.ts
+++ b/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.ts
@@ -39,6 +39,6 @@ export class CreatureTemplateResistanceComponent extends MultiRowEditorComponent
 
   protected readonly CREATURE_TEMPLATE_RESISTANCE_SCHOOL = CREATURE_TEMPLATE_RESISTANCE_SCHOOL;
 
-  override readonly editorService = inject(CreatureTemplateResistanceService);
+  protected override readonly editorService = inject(CreatureTemplateResistanceService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/creature-template-spell/creature-template-spell.component.ts
+++ b/libs/features/creature/src/creature-template-spell/creature-template-spell.component.ts
@@ -38,7 +38,7 @@ export class CreatureTemplateSpellComponent extends MultiRowEditorComponent<Crea
 
   protected readonly SPELL_INDEXES = [0, 1, 2, 3, 4, 5, 6, 7];
 
-  override readonly editorService = inject(CreatureTemplateSpellService);
+  protected override readonly editorService = inject(CreatureTemplateSpellService);
   readonly handlerService = inject(CreatureHandlerService);
   readonly sqliteQueryService = inject(SqliteQueryService);
 }

--- a/libs/features/creature/src/creature-template/creature-template.component.ts
+++ b/libs/features/creature/src/creature-template/creature-template.component.ts
@@ -91,6 +91,6 @@ export class CreatureTemplateComponent extends SingleRowEditorComponent<Creature
   protected RACE_ICON_GENDER = true;
   protected showCreaturePreview = false;
 
-  override readonly editorService = inject(CreatureTemplateService);
+  protected override readonly editorService = inject(CreatureTemplateService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/creature-text/creature-text.component.ts
+++ b/libs/features/creature/src/creature-text/creature-text.component.ts
@@ -40,6 +40,6 @@ export class CreatureTextComponent extends MultiRowEditorComponent<CreatureText>
   protected readonly TEXT_RANGE = TEXT_RANGE;
   protected readonly EMOTE = EMOTE;
 
-  public override readonly editorService = inject(CreatureTextService);
+  protected override readonly editorService = inject(CreatureTextService);
   protected override readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/npc-trainer/npc-trainer.component.ts
+++ b/libs/features/creature/src/npc-trainer/npc-trainer.component.ts
@@ -34,7 +34,7 @@ import { NpcTrainerService } from './npc-trainer.service';
   ],
 })
 export class NpcTrainerComponent extends MultiRowEditorComponent<NpcTrainer> {
-  override readonly editorService = inject(NpcTrainerService);
+  protected override readonly editorService = inject(NpcTrainerService);
   readonly handlerService = inject(CreatureHandlerService);
   readonly sqliteQueryService = inject(SqliteQueryService);
 }

--- a/libs/features/creature/src/npc-vendor/npc-vendor.component.ts
+++ b/libs/features/creature/src/npc-vendor/npc-vendor.component.ts
@@ -33,6 +33,6 @@ import { NpcVendorService } from './npc-vendor.service';
   ],
 })
 export class NpcVendorComponent extends MultiRowEditorComponent<NpcVendor> {
-  override readonly editorService = inject(NpcVendorService);
+  protected override readonly editorService = inject(NpcVendorService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/pickpocketing-loot-template/pickpocketing-loot-template.component.ts
+++ b/libs/features/creature/src/pickpocketing-loot-template/pickpocketing-loot-template.component.ts
@@ -14,6 +14,6 @@ import { TopBarComponent } from '@keira/shared/base-editor-components';
   imports: [TopBarComponent, LootEditorComponent],
 })
 export class PickpocketingLootTemplateComponent extends LootTemplateIdComponent<PickpocketingLootTemplate> {
-  override readonly editorService = inject(PickpocketingLootTemplateService);
+  protected override readonly editorService = inject(PickpocketingLootTemplateService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/creature/src/skinning-loot-template/skinning-loot-template.component.ts
+++ b/libs/features/creature/src/skinning-loot-template/skinning-loot-template.component.ts
@@ -14,6 +14,6 @@ import { TopBarComponent } from '@keira/shared/base-editor-components';
   imports: [TopBarComponent, LootEditorComponent],
 })
 export class SkinningLootTemplateComponent extends LootTemplateIdComponent<SkinningLootTemplate> {
-  override readonly editorService = inject(SkinningLootTemplateService);
+  protected override readonly editorService = inject(SkinningLootTemplateService);
   readonly handlerService = inject(CreatureHandlerService);
 }

--- a/libs/features/gameobject/src/gameobject-loot-template/gameobject-loot-template.component.ts
+++ b/libs/features/gameobject/src/gameobject-loot-template/gameobject-loot-template.component.ts
@@ -35,7 +35,7 @@ export class GameobjectLootTemplateComponent extends LootTemplateIdComponent<Gam
     );
   }
 
-  override readonly editorService = inject(GameobjectLootTemplateService);
+  protected override readonly editorService = inject(GameobjectLootTemplateService);
   readonly handlerService = inject(GameobjectHandlerService);
 
   override ngOnInit() {

--- a/libs/features/gameobject/src/gameobject-questitem/gameobject-questitem.component.ts
+++ b/libs/features/gameobject/src/gameobject-questitem/gameobject-questitem.component.ts
@@ -30,6 +30,6 @@ import { GameobjectQuestitemService } from './gameobject-questitem.service';
   ],
 })
 export class GameobjectQuestitemComponent extends MultiRowEditorComponent<GameobjectQuestitem> {
-  override readonly editorService = inject(GameobjectQuestitemService);
+  protected override readonly editorService = inject(GameobjectQuestitemService);
   readonly handlerService = inject(GameobjectHandlerService);
 }

--- a/libs/features/gameobject/src/gameobject-spawn-addon/gameobject-spawn-addon.component.ts
+++ b/libs/features/gameobject/src/gameobject-spawn-addon/gameobject-spawn-addon.component.ts
@@ -29,6 +29,6 @@ import { GameobjectSpawnAddonService } from './gameobject-spawn-addon.service';
 export class GameobjectSpawnAddonComponent extends MultiRowEditorComponent<GameobjectSpawnAddon> {
   readonly INVISIBILITY_TYPE = INVISIBILITY_TYPE;
 
-  override readonly editorService = inject(GameobjectSpawnAddonService);
+  protected override readonly editorService = inject(GameobjectSpawnAddonService);
   readonly handlerService = inject(GameobjectHandlerService);
 }

--- a/libs/features/gameobject/src/gameobject-spawn/gameobject-spawn.component.ts
+++ b/libs/features/gameobject/src/gameobject-spawn/gameobject-spawn.component.ts
@@ -34,6 +34,6 @@ export class GameobjectSpawnComponent extends MultiRowEditorComponent<Gameobject
   readonly SPAWN_MASK = SPAWN_MASK;
   readonly PHASE_MASK = PHASE_MASK;
 
-  override readonly editorService = inject(GameobjectSpawnService);
+  protected override readonly editorService = inject(GameobjectSpawnService);
   readonly handlerService = inject(GameobjectHandlerService);
 }

--- a/libs/features/gameobject/src/gameobject-template-addon/gameobject-template-addon.component.ts
+++ b/libs/features/gameobject/src/gameobject-template-addon/gameobject-template-addon.component.ts
@@ -29,6 +29,6 @@ import { GameobjectTemplateAddonService } from './gameobject-template-addon.serv
 export class GameobjectTemplateAddonComponent extends SingleRowEditorComponent<GameobjectTemplateAddon> {
   readonly GAMEOBJECT_FLAGS = GAMEOBJECT_FLAGS;
 
-  override readonly editorService = inject(GameobjectTemplateAddonService);
+  protected override readonly editorService = inject(GameobjectTemplateAddonService);
   readonly handlerService = inject(GameobjectHandlerService);
 }

--- a/libs/features/gameobject/src/gameobject-template/gameobject-template.component.ts
+++ b/libs/features/gameobject/src/gameobject-template/gameobject-template.component.ts
@@ -36,7 +36,7 @@ export class GameobjectTemplateComponent extends SingleRowEditorComponent<Gameob
 
   showGameobjectPreview = true;
 
-  override readonly editorService = inject(GameobjectTemplateService);
+  protected override readonly editorService = inject(GameobjectTemplateService);
   readonly handlerService = inject(GameobjectHandlerService);
 
   dataFieldDefinition(dataIndex: number): FieldDefinition {

--- a/libs/features/gossip/src/gossip-menu-option/gossip-menu-option.component.ts
+++ b/libs/features/gossip/src/gossip-menu-option/gossip-menu-option.component.ts
@@ -34,7 +34,7 @@ export class GossipMenuOptionComponent extends MultiRowEditorComponent<GossipMen
   readonly OPTION_ICON = OPTION_ICON;
   readonly OPTION_TYPE = OPTION_TYPE;
 
-  override readonly editorService = inject(GossipMenuOptionService);
+  protected override readonly editorService = inject(GossipMenuOptionService);
   readonly handlerService = inject(GossipHandlerService);
 
   showGossipPreview = true;

--- a/libs/features/gossip/src/gossip-menu/gossip-menu.component.ts
+++ b/libs/features/gossip/src/gossip-menu/gossip-menu.component.ts
@@ -32,7 +32,7 @@ import { GossipMenuService } from './gossip-menu.service';
   ],
 })
 export class GossipMenuComponent extends MultiRowEditorComponent<GossipMenu> {
-  override readonly editorService = inject(GossipMenuService);
+  protected override readonly editorService = inject(GossipMenuService);
   readonly handlerService = inject(GossipHandlerService);
   readonly queryService = inject(MysqlQueryService);
 }

--- a/libs/features/item/src/item-enchantment/item-enchantment-template.component.ts
+++ b/libs/features/item/src/item-enchantment/item-enchantment-template.component.ts
@@ -25,6 +25,6 @@ import { TranslateModule } from '@ngx-translate/core';
   ],
 })
 export class ItemEnchantmentTemplateComponent extends MultiRowEditorComponent<ItemEnchantmentTemplate> {
-  override readonly editorService = inject(ItemEnchantmentTemplateService);
+  protected override readonly editorService = inject(ItemEnchantmentTemplateService);
   readonly handlerService = inject(ItemHandlerService);
 }

--- a/libs/features/item/src/item-loot-template/item-loot-template.component.ts
+++ b/libs/features/item/src/item-loot-template/item-loot-template.component.ts
@@ -14,6 +14,6 @@ import { ItemLootTemplateService } from './item-loot-template.service';
   imports: [TopBarComponent, LootEditorComponent],
 })
 export class ItemLootTemplateComponent extends LootTemplateComponent<ItemLootTemplate> {
-  override readonly editorService = inject(ItemLootTemplateService);
+  protected override readonly editorService = inject(ItemLootTemplateService);
   readonly handlerService = inject(ItemHandlerService);
 }

--- a/libs/features/item/src/item-template/item-template.component.ts
+++ b/libs/features/item/src/item-template/item-template.component.ts
@@ -80,7 +80,7 @@ import { ItemTemplateService } from './item-template.service';
   ],
 })
 export class ItemTemplateComponent extends SingleRowEditorComponent<ItemTemplate> implements OnInit {
-  override readonly editorService = inject(ItemTemplateService);
+  protected override readonly editorService = inject(ItemTemplateService);
   readonly handlerService = inject(ItemHandlerService);
   private readonly itemPreviewService = inject(ItemPreviewService);
   private readonly sanitizer = inject(DomSanitizer);

--- a/libs/features/item/src/milling-loot-template/milling-loot-template.component.ts
+++ b/libs/features/item/src/milling-loot-template/milling-loot-template.component.ts
@@ -14,6 +14,6 @@ import { TopBarComponent } from '@keira/shared/base-editor-components';
   imports: [TopBarComponent, LootEditorComponent],
 })
 export class MillingLootTemplateComponent extends LootTemplateComponent<MillingLootTemplate> {
-  override readonly editorService = inject(MillingLootTemplateService);
+  protected override readonly editorService = inject(MillingLootTemplateService);
   readonly handlerService = inject(ItemHandlerService);
 }

--- a/libs/features/item/src/prospecting-loot-template/prospecting-loot-template.component.ts
+++ b/libs/features/item/src/prospecting-loot-template/prospecting-loot-template.component.ts
@@ -14,6 +14,6 @@ import { TopBarComponent } from '@keira/shared/base-editor-components';
   imports: [TopBarComponent, LootEditorComponent],
 })
 export class ProspectingLootTemplateComponent extends LootTemplateComponent<ProspectingLootTemplate> {
-  override readonly editorService = inject(ProspectingLootTemplateService);
+  protected override readonly editorService = inject(ProspectingLootTemplateService);
   readonly handlerService = inject(ItemHandlerService);
 }

--- a/libs/features/other-loots/src/fishing-loot/fishing-loot-template.component.ts
+++ b/libs/features/other-loots/src/fishing-loot/fishing-loot-template.component.ts
@@ -15,6 +15,6 @@ import { TopBarComponent } from '@keira/shared/base-editor-components';
   imports: [TopBarComponent, TranslateModule, LootEditorComponent],
 })
 export class FishingLootTemplateComponent extends LootTemplateComponent<FishingLootTemplate> {
-  override readonly editorService = inject(FishingLootTemplateService);
+  protected override readonly editorService = inject(FishingLootTemplateService);
   readonly handlerService = inject(FishingLootHandlerService);
 }

--- a/libs/features/other-loots/src/mail-loot/mail-loot-template.component.ts
+++ b/libs/features/other-loots/src/mail-loot/mail-loot-template.component.ts
@@ -15,6 +15,6 @@ import { TopBarComponent } from '@keira/shared/base-editor-components';
   imports: [TopBarComponent, TranslateModule, LootEditorComponent],
 })
 export class MailLootTemplateComponent extends LootTemplateComponent<MailLootTemplate> {
-  override readonly editorService = inject(MailLootTemplateService);
+  protected override readonly editorService = inject(MailLootTemplateService);
   readonly handlerService = inject(MailLootHandlerService);
 }

--- a/libs/features/other-loots/src/reference-loot/reference-loot-template.component.ts
+++ b/libs/features/other-loots/src/reference-loot/reference-loot-template.component.ts
@@ -15,6 +15,6 @@ import { TopBarComponent } from '@keira/shared/base-editor-components';
   imports: [TopBarComponent, TranslateModule, LootEditorComponent],
 })
 export class ReferenceLootTemplateComponent extends LootTemplateComponent<ReferenceLootTemplate> {
-  override readonly editorService = inject(ReferenceLootTemplateService);
+  protected override readonly editorService = inject(ReferenceLootTemplateService);
   readonly handlerService = inject(ReferenceLootHandlerService);
 }

--- a/libs/features/other-loots/src/spell-loot/spell-loot-template.component.ts
+++ b/libs/features/other-loots/src/spell-loot/spell-loot-template.component.ts
@@ -15,6 +15,6 @@ import { LootEditorComponent } from '@keira/shared/loot-editor';
   imports: [TopBarComponent, TranslateModule, LootEditorComponent],
 })
 export class SpellLootTemplateComponent extends LootTemplateComponent<SpellLootTemplate> {
-  override readonly editorService = inject(SpellLootTemplateService);
+  protected override readonly editorService = inject(SpellLootTemplateService);
   readonly handlerService = inject(SpellLootHandlerService);
 }

--- a/libs/features/quest/src/creature-questender/creature-questender.component.ts
+++ b/libs/features/quest/src/creature-questender/creature-questender.component.ts
@@ -34,7 +34,7 @@ import { CreatureQuestenderService } from './creature-questender.service';
   ],
 })
 export class CreatureQuestenderComponent extends MultiRowEditorComponent<CreatureQuestender> {
-  override readonly editorService = inject(CreatureQuestenderService);
+  protected override readonly editorService = inject(CreatureQuestenderService);
   readonly handlerService = inject(QuestHandlerService);
   readonly questPreviewService = inject(QuestPreviewService);
 }

--- a/libs/features/quest/src/creature-queststarter/creature-queststarter.component.ts
+++ b/libs/features/quest/src/creature-queststarter/creature-queststarter.component.ts
@@ -34,7 +34,7 @@ import { CreatureQueststarterService } from './creature-queststarter.service';
   ],
 })
 export class CreatureQueststarterComponent extends MultiRowEditorComponent<CreatureQueststarter> {
-  override readonly editorService = inject(CreatureQueststarterService);
+  protected override readonly editorService = inject(CreatureQueststarterService);
   readonly handlerService = inject(QuestHandlerService);
   readonly questPreviewService = inject(QuestPreviewService);
 }

--- a/libs/features/quest/src/gameobject-questender/gameobject-questender.component.ts
+++ b/libs/features/quest/src/gameobject-questender/gameobject-questender.component.ts
@@ -34,7 +34,7 @@ import { GameobjectQuestenderService } from './gameobject-questender.service';
   ],
 })
 export class GameobjectQuestenderComponent extends MultiRowEditorComponent<GameobjectQuestender> {
-  override readonly editorService = inject(GameobjectQuestenderService);
+  protected override readonly editorService = inject(GameobjectQuestenderService);
   readonly handlerService = inject(QuestHandlerService);
   readonly questPreviewService = inject(QuestPreviewService);
 }

--- a/libs/features/quest/src/gameobject-queststarter/gameobject-queststarter.component.ts
+++ b/libs/features/quest/src/gameobject-queststarter/gameobject-queststarter.component.ts
@@ -34,7 +34,7 @@ import { GameobjectQueststarterService } from './gameobject-queststarter.service
   ],
 })
 export class GameobjectQueststarterComponent extends MultiRowEditorComponent<GameobjectQueststarter> {
-  override readonly editorService = inject(GameobjectQueststarterService);
+  protected override readonly editorService = inject(GameobjectQueststarterService);
   readonly handlerService = inject(QuestHandlerService);
   readonly questPreviewService = inject(QuestPreviewService);
 }

--- a/libs/features/quest/src/quest-offer-reward/quest-offer-reward.component.ts
+++ b/libs/features/quest/src/quest-offer-reward/quest-offer-reward.component.ts
@@ -31,7 +31,7 @@ import { QuestOfferRewardService } from './quest-offer-reward.service';
 export class QuestOfferRewardComponent extends SingleRowEditorComponent<QuestOfferReward> {
   readonly EMOTE = EMOTE;
 
-  override readonly editorService = inject(QuestOfferRewardService);
+  protected override readonly editorService = inject(QuestOfferRewardService);
   readonly handlerService = inject(QuestHandlerService);
   readonly questPreviewService = inject(QuestPreviewService);
 }

--- a/libs/features/quest/src/quest-request-items/quest-request-items.component.ts
+++ b/libs/features/quest/src/quest-request-items/quest-request-items.component.ts
@@ -29,7 +29,7 @@ import { QuestRequestItemsService } from './quest-request-items.service';
   ],
 })
 export class QuestRequestItemsComponent extends SingleRowEditorComponent<QuestRequestItems> {
-  override readonly editorService = inject(QuestRequestItemsService);
+  protected override readonly editorService = inject(QuestRequestItemsService);
   readonly handlerService = inject(QuestHandlerService);
   readonly questPreviewService = inject(QuestPreviewService);
 

--- a/libs/features/quest/src/quest-template-addon/quest-template-addon.component.ts
+++ b/libs/features/quest/src/quest-template-addon/quest-template-addon.component.ts
@@ -39,7 +39,7 @@ import { QuestTemplateAddonService } from './quest-template-addon.service';
   ],
 })
 export class QuestTemplateAddonComponent extends SingleRowEditorComponent<QuestTemplateAddon> {
-  override readonly editorService = inject(QuestTemplateAddonService);
+  protected override readonly editorService = inject(QuestTemplateAddonService);
   readonly handlerService = inject(QuestHandlerService);
   readonly questPreviewService = inject(QuestPreviewService);
 

--- a/libs/features/quest/src/quest-template/quest-template.component.ts
+++ b/libs/features/quest/src/quest-template/quest-template.component.ts
@@ -42,7 +42,7 @@ import { QuestTemplateService } from './quest-template.service';
   ],
 })
 export class QuestTemplateComponent extends SingleRowEditorComponent<QuestTemplate> {
-  override readonly editorService = inject(QuestTemplateService);
+  protected override readonly editorService = inject(QuestTemplateService);
   readonly handlerService = inject(QuestHandlerService);
   readonly questPreviewService = inject(QuestPreviewService);
 

--- a/libs/features/spell/src/spell-dbc/spell-dbc.component.ts
+++ b/libs/features/spell/src/spell-dbc/spell-dbc.component.ts
@@ -36,6 +36,6 @@ import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor
   ],
 })
 export class SpellDbcComponent extends SingleRowEditorComponent<SpellDbc> {
-  override readonly editorService = inject(SpellDbcService);
+  protected override readonly editorService = inject(SpellDbcService);
   readonly handlerService = inject(SpellHandlerService);
 }

--- a/libs/features/texts/src/broadcast-text/broadcast-text.component.ts
+++ b/libs/features/texts/src/broadcast-text/broadcast-text.component.ts
@@ -26,7 +26,7 @@ import { BroadcastTextService } from './broadcast-text.service';
   ],
 })
 export class BroadcastTextComponent extends SingleRowEditorComponent<BroadcastText> {
-  override readonly editorService = inject(BroadcastTextService);
+  protected override readonly editorService = inject(BroadcastTextService);
   protected override readonly handlerService = inject(BroadcastTextHandlerService);
 
   protected readonly EMOTE = EMOTE;

--- a/libs/features/texts/src/npc-text/npc-text.component.ts
+++ b/libs/features/texts/src/npc-text/npc-text.component.ts
@@ -26,6 +26,6 @@ import { NpcTextFieldsGroupComponent } from './npc-text-fields-group.component';
   ],
 })
 export class NpcTextComponent extends SingleRowEditorComponent<NpcText> {
-  override readonly editorService = inject(NpcTextService);
+  protected override readonly editorService = inject(NpcTextService);
   protected override readonly handlerService = inject(NpcTextHandlerService);
 }

--- a/libs/features/texts/src/page-text/page-text.component.ts
+++ b/libs/features/texts/src/page-text/page-text.component.ts
@@ -24,6 +24,6 @@ import { PageText } from '@keira/shared/acore-world-model';
   ],
 })
 export class PageTextComponent extends SingleRowEditorComponent<PageText> {
-  override readonly editorService = inject(PageTextService);
+  protected override readonly editorService = inject(PageTextService);
   protected override readonly handlerService = inject(PageTextHandlerService);
 }

--- a/libs/shared/base-abstract-classes/src/components/editors/editor.component.ts
+++ b/libs/shared/base-abstract-classes/src/components/editors/editor.component.ts
@@ -11,7 +11,7 @@ import { HandlerService } from '../../service/handlers/handler.service';
   template: '',
 })
 export abstract class EditorComponent<T extends TableRow> extends SubscriptionHandler implements OnInit {
-  public abstract readonly editorService: EditorService<T>;
+  protected abstract readonly editorService: EditorService<T>;
   protected abstract readonly handlerService: HandlerService<T>;
 
   readonly WIKI_BASE_URL = WIKI_BASE_URL;

--- a/libs/shared/base-abstract-classes/src/components/editors/loot-template/loot-template-id.component.ts
+++ b/libs/shared/base-abstract-classes/src/components/editors/loot-template/loot-template-id.component.ts
@@ -13,7 +13,7 @@ import { LootTemplateComponent } from './loot-template.component';
   template: '',
 })
 export abstract class LootTemplateIdComponent<T extends LootTemplate> extends LootTemplateComponent<T> implements OnInit {
-  public abstract override editorService: LootEditorIdService<T>;
+  protected abstract override editorService: LootEditorIdService<T>;
   protected abstract override handlerService: HandlerService<T>;
 
   protected _lootId!: number;

--- a/libs/shared/base-abstract-classes/src/components/editors/multi-row-editor.component.ts
+++ b/libs/shared/base-abstract-classes/src/components/editors/multi-row-editor.component.ts
@@ -10,7 +10,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   template: '',
 })
 export abstract class MultiRowEditorComponent<T extends TableRow> extends EditorComponent<T> {
-  public abstract override readonly editorService: MultiRowEditorService<T>;
+  protected abstract override readonly editorService: MultiRowEditorService<T>;
   protected abstract override readonly handlerService: HandlerService<T>;
 
   readonly DTCFG = DTCFG;

--- a/libs/shared/base-abstract-classes/src/components/editors/select.component.ts
+++ b/libs/shared/base-abstract-classes/src/components/editors/select.component.ts
@@ -7,10 +7,10 @@ import { HandlerService } from '../../service/handlers/handler.service';
 import { DTCFG } from '@keira/shared/config';
 
 export abstract class SelectComponent<T extends TableRow> {
-  abstract readonly entityTable: string;
-  abstract readonly entityIdField: string;
-  abstract readonly customStartingId: number;
-  abstract readonly selectService: SelectService<T>;
+  protected abstract readonly entityTable: string;
+  protected abstract readonly entityIdField: string;
+  protected abstract readonly customStartingId: number;
+  protected abstract readonly selectService: SelectService<T>;
   abstract readonly handlerService: HandlerService<T>;
 
   readonly queryService = inject(MysqlQueryService);

--- a/libs/shared/base-abstract-classes/src/components/editors/single-row-editor.component.ts
+++ b/libs/shared/base-abstract-classes/src/components/editors/single-row-editor.component.ts
@@ -9,6 +9,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   template: '',
 })
 export abstract class SingleRowEditorComponent<T extends TableRow> extends EditorComponent<T> {
-  public abstract override readonly editorService: SingleRowEditorService<T>;
+  protected abstract override readonly editorService: SingleRowEditorService<T>;
   protected abstract override readonly handlerService: HandlerService<T>;
 }

--- a/libs/shared/sai-editor/src/sai-editor.component.ts
+++ b/libs/shared/sai-editor/src/sai-editor.component.ts
@@ -87,7 +87,7 @@ import { EditorButtonsComponent, QueryOutputComponent } from '@keira/shared/base
   ],
 })
 export class SaiEditorComponent extends MultiRowEditorComponent<SmartScripts> implements OnInit {
-  override readonly editorService = inject(SaiEditorService);
+  public override readonly editorService = inject(SaiEditorService);
   protected override readonly handlerService = inject(SaiHandlerService);
 
   readonly EVENT_PHASE_MASK = EVENT_PHASE_MASK;


### PR DESCRIPTION
As mentioned [here](https://github.com/azerothcore/Keira3/pull/3210#discussion_r1894425492) the editor in components can be made protected. 
This PR does that for all currently available editors. 
I hope that this change is helpful