### PR TITLE
ci: add new workflow to sync i18n files

### DIFF
--- a/.github/workflows/sync_i18n.yml
+++ b/.github/workflows/sync_i18n.yml
@@ -1,0 +1,41 @@
+name: Check and Fix Missing Translation Keys
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-translation-keys:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: pip install json-delta
+
+      - name: Run Python script to check and fix missing keys
+        run: |
+          python scripts/sync_i18n.py
+
+      - name: Commit and push changes if necessary
+        run: |
+          if [ "$(git status --porcelain)" != "" ]; then
+            git config user.name "i18n Sync Bot"
+            git config user.email "action@github.com"
+            git add apps/keira/src/assets/i18n/*.json
+            git commit -m "Fix missing translation keys"
+            git push
+          else
+            echo "No missing keys detected."
+          fi

--- a/scripts/sync_i18n.py
+++ b/scripts/sync_i18n.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 
 
-def merge_with_en(en_data, target_data):
+def merge_with_en(en_data: dict, target_data: dict) -> dict:
     """
     Recursively merge en.json keys into target translation file.
     - Adds missing keys from en.json.
@@ -24,7 +24,7 @@ def merge_with_en(en_data, target_data):
     return merged
 
 
-def sync_keys(translations_dir, en_file):
+def sync_keys(translations_dir: Path, en_file: Path):
     # Load en.json as the reference file
     with open(en_file, 'r', encoding='utf-8') as f:
         en_data = json.load(f)
@@ -47,5 +47,5 @@ def sync_keys(translations_dir, en_file):
 
 if __name__ == "__main__":
     translations_dir = Path("apps", "keira", "src", "assets", "i18n")  # Update to your directory
-    en_file = translations_dir / "en.json"
+    en_file = Path(translations_dir, "en.json")
     sync_keys(translations_dir, en_file)

--- a/scripts/sync_i18n.py
+++ b/scripts/sync_i18n.py
@@ -1,0 +1,51 @@
+import os
+import json
+from pathlib import Path
+
+
+def merge_with_en(en_data, target_data):
+    """
+    Recursively merge en.json keys into target translation file.
+    - Adds missing keys from en.json.
+    - Preserves existing keys and values in the target file.
+    - Removes keys not present in en.json.
+    """
+    merged = {}
+    for key, value in en_data.items():
+        if key in target_data:
+            # If key exists in both, check if it's a nested dictionary
+            if isinstance(value, dict) and isinstance(target_data[key], dict):
+                merged[key] = merge_with_en(value, target_data[key])
+            else:
+                merged[key] = target_data[key]  # Preserve existing value
+        else:
+            merged[key] = value  # Add missing key with value from en.json
+
+    return merged
+
+
+def sync_keys(translations_dir, en_file):
+    # Load en.json as the reference file
+    with open(en_file, 'r', encoding='utf-8') as f:
+        en_data = json.load(f)
+
+    for file in os.listdir(translations_dir):
+        if file.endswith('.json') and file != os.path.basename(en_file):
+            file_path = os.path.join(translations_dir, file)
+            with open(file_path, 'r', encoding='utf-8') as f:
+                target_data = json.load(f)
+
+            # Synchronize keys with en.json
+            synced_data = merge_with_en(en_data, target_data)
+
+            # Save the synchronized file
+            with open(file_path, 'w', encoding='utf-8') as f:
+                json.dump(synced_data, f, ensure_ascii=False, indent=2)
+
+            print(f"Synced {file}")
+
+
+if __name__ == "__main__":
+    translations_dir = Path("apps", "keira", "src", "assets", "i18n")  # Update to your directory
+    en_file = translations_dir / "en.json"
+    sync_keys(translations_dir, en_file)

--- a/scripts/sync_i18n.py
+++ b/scripts/sync_i18n.py
@@ -2,7 +2,6 @@ import os
 import json
 from pathlib import Path
 
-
 def merge_with_en(en_data: dict, target_data: dict) -> dict:
     """
     Recursively merge en.json keys into target translation file.
@@ -23,8 +22,7 @@ def merge_with_en(en_data: dict, target_data: dict) -> dict:
 
     return merged
 
-
-def sync_keys(translations_dir: Path, en_file: Path):
+def sync_keys(translations_dir: Path, en_file: Path) -> None:
     # Load en.json as the reference file
     with open(en_file, 'r', encoding='utf-8') as f:
         en_data = json.load(f)


### PR DESCRIPTION
Using en.json as default to sync all keys across the available json files. 
Commits the adjustments if necessary.
Closes #3211

Example fix can be seen here:
https://github.com/Exitare/Keira3/commit/435a29eca18f67351cfd4b7e8edaf47335aefffc