### PR TITLE
fix(npc-vendor): wrong color for item extended cost.

### DIFF
--- a/apps/keira/src/app/scss/_utils.scss
+++ b/apps/keira/src/app/scss/_utils.scss
@@ -52,8 +52,8 @@ input[type='radio'] {
 }
 .item-extended-cost {
   display: inline-block;
-  background-color: #080d22;
-  color: #fff;
+  background-color: inherit;
+  color: inherit;
   padding: 4px 10px 4px 0px;
 }
 .item-extended-cost img {

--- a/libs/features/creature/src/npc-vendor/npc-vendor.component.html
+++ b/libs/features/creature/src/npc-vendor/npc-vendor.component.html
@@ -21,7 +21,6 @@
               <keira-item-selector-btn
                 [control]="editorService.form.controls.item"
                 [disabled]="editorService.form.controls.item.disabled"
-                [disabled]="editorService.form.controls.item.disabled"
                 [config]="{ name: 'item' }"
               />
               <input [formControlName]="'item'" id="item" type="number" class="form-control form-control-sm" />


### PR DESCRIPTION
Closes #3248

Item extended cost now inherits style from parent component. 
Additionally, I removed a duplicate disabled element.