### PR TITLE
Add default behaviour override for flag selectors.

### DIFF
--- a/libs/features/item/src/item-template/item-template.component.html
+++ b/libs/features/item/src/item-template/item-template.component.html
@@ -310,7 +310,7 @@
               <keira-flags-selector-btn
                 [control]="editorService.form.controls.AllowableClass"
                 [disabled]="editorService.form.controls.AllowableClass.disabled"
-                [config]="{ flags: ALLOWABLE_CLASSES, name: 'AllowableClass' }"
+                [config]="{ flags: ALLOWABLE_CLASSES, name: 'AllowableClass', overrideDefaultBehavior: true }"
                 [modalClass]="'modal-lg'"
               />
               <input [formControlName]="'AllowableClass'" id="AllowableClass" type="number" class="form-control form-control-sm" />
@@ -320,7 +320,7 @@
               <keira-flags-selector-btn
                 [control]="editorService.form.controls.AllowableRace"
                 [disabled]="editorService.form.controls.AllowableRace.disabled"
-                [config]="{ flags: ALLOWABLE_RACES, name: 'AllowableRace' }"
+                [config]="{ flags: ALLOWABLE_RACES, name: 'AllowableRace', overrideDefaultBehavior: true }"
                 [modalClass]="'modal-lg'"
               />
               <input [formControlName]="'AllowableRace'" id="AllowableRace" type="number" class="form-control form-control-sm" />

--- a/libs/shared/selectors/src/selectors/flags-selector/flags-selector-modal.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/flags-selector/flags-selector-modal.component.spec.ts
@@ -54,7 +54,32 @@ describe('FlagsSelectorModalComponent', () => {
 
     expect(component.flagValues).toEqual([true, true, true]);
     expect(spyGetValueFromBits).toHaveBeenCalledTimes(1);
-    expect(spyGetValueFromBits).toHaveBeenCalledWith([true, true, true]);
+    expect(spyGetValueFromBits).toHaveBeenCalledWith([true, true, true], false);
     expect(component.value).toEqual(value);
+  });
+
+  it('toggleBit() override should properly work', () => {
+    const value = 123456;
+    const overrideDefaultBehavior = true;
+    const flags = [{ bit: 1, name: 'flag-1' }];
+    const initialFlagValues = [true, false, true];
+    const updatedValue = 654321;
+
+    // Set up the component's initial state
+    component.value = value;
+    component.config = { name: 'Mock Modal Name', flags, overrideDefaultBehavior };
+    component.flagValues = [...initialFlagValues];
+
+    // Spy on the flagsService.getValueFromBits method
+    const spyGetValueFromBits = spyOn(flagsService, 'getValueFromBits').and.returnValue(updatedValue);
+
+    // Act: Call toggleBit with a specific bit index
+    component.toggleBit(1); // Toggle the second bit (index 1)
+
+    // Assertions
+    expect(component.flagValues).toEqual([true, true, true]); // Bit at index 1 should toggle to `true`
+    expect(spyGetValueFromBits).toHaveBeenCalledTimes(1);
+    expect(spyGetValueFromBits).toHaveBeenCalledWith([true, true, true], overrideDefaultBehavior);
+    expect(component.value).toEqual(updatedValue); // Value should update based on the override behavior
   });
 });

--- a/libs/shared/selectors/src/selectors/flags-selector/flags-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/flags-selector/flags-selector-modal.component.ts
@@ -28,6 +28,6 @@ export class FlagsSelectorModalComponent extends BaseSelectorModalComponent<Flag
 
   toggleBit(bit: number) {
     this.flagValues[bit] = !this.flagValues[bit];
-    this.value = this.flagsService.getValueFromBits(this.flagValues);
+    this.value = this.flagsService.getValueFromBits(this.flagValues, this.config?.overrideDefaultBehavior ?? false);
   }
 }

--- a/libs/shared/selectors/src/selectors/flags-selector/flags-selector.model.ts
+++ b/libs/shared/selectors/src/selectors/flags-selector/flags-selector.model.ts
@@ -3,4 +3,5 @@ import { Flag } from '@keira/shared/constants';
 
 export interface FlagsModalConfig extends BaseModalConfig {
   flags: Flag[];
+  overrideDefaultBehavior?: boolean;
 }

--- a/libs/shared/selectors/src/selectors/flags-selector/flags.service.spec.ts
+++ b/libs/shared/selectors/src/selectors/flags-selector/flags.service.spec.ts
@@ -61,4 +61,29 @@ describe('FlagsService', () => {
     expect(service.getBitsArray(flags, value)).toEqual(mockResult);
     expect(getBitsFromValueSpy).toHaveBeenCalledWith(value, flags[0].bit + 1);
   });
+
+  it('should handle value -1 (all bits not set)', () => {
+    const service = TestBed.inject(FlagsService);
+    expect(service.getBitsFromValue(-1, 5)).toEqual([false, false, false, false, false]);
+  });
+
+  it('should handle value 0 (all bits unset)', () => {
+    const service = TestBed.inject(FlagsService);
+    expect(service.getBitsFromValue(0, 3)).toEqual([false, false, false]);
+  });
+
+  it('should handle count 0 (empty bits array)', () => {
+    const service = TestBed.inject(FlagsService);
+    expect(service.getBitsFromValue(5, 0)).toEqual([]);
+  });
+
+  it('should return -1 when overrideDefaultBehavior is true and all bits are false', () => {
+    const service = TestBed.inject(FlagsService);
+    expect(service.getValueFromBits([false, false, false], true)).toEqual(-1);
+  });
+
+  it('should return 0 when overrideDefaultBehavior is false and all bits are false', () => {
+    const service = TestBed.inject(FlagsService);
+    expect(service.getValueFromBits([false, false, false], false)).toEqual(0);
+  });
 });

--- a/libs/shared/selectors/src/selectors/flags-selector/flags.service.ts
+++ b/libs/shared/selectors/src/selectors/flags-selector/flags.service.ts
@@ -7,7 +7,9 @@ import { Flag } from '@keira/shared/constants';
 export class FlagsService {
   getBitsFromValue(value: number, bitsCount: number): boolean[] {
     const bits = new Array<boolean>(bitsCount);
-    const binaryStr: string = value.toString(2).split('').reverse().join('');
+
+    let binaryStr: string = '0'.repeat(bitsCount);
+    if (value !== -1) binaryStr = value.toString(2).split('').reverse().join('');
 
     for (let i = 0; i < bitsCount; i++) {
       bits[i] = parseInt(binaryStr[i], 10) === 1;
@@ -16,7 +18,10 @@ export class FlagsService {
     return bits;
   }
 
-  getValueFromBits(bits: boolean[]): number {
+  getValueFromBits(bits: boolean[], overrideDefaultBehavior: boolean = false): number {
+    // override default behavior if all bits are false
+    if (overrideDefaultBehavior && bits.every((bit) => !bit)) return -1;
+
     let result = 0;
 
     for (let i = 0; i < bits.length; i++) {

--- a/libs/shared/selectors/src/selectors/flags-selector/flags.service.ts
+++ b/libs/shared/selectors/src/selectors/flags-selector/flags.service.ts
@@ -7,9 +7,7 @@ import { Flag } from '@keira/shared/constants';
 export class FlagsService {
   getBitsFromValue(value: number, bitsCount: number): boolean[] {
     const bits = new Array<boolean>(bitsCount);
-
-    let binaryStr: string = '0'.repeat(bitsCount);
-    if (value !== -1) binaryStr = value.toString(2).split('').reverse().join('');
+    const binaryStr: string = value !== -1 ? value.toString(2).split('').reverse().join('') : '0'.repeat(bitsCount);
 
     for (let i = 0; i < bitsCount; i++) {
       bits[i] = parseInt(binaryStr[i], 10) === 1;
@@ -20,7 +18,9 @@ export class FlagsService {
 
   getValueFromBits(bits: boolean[], overrideDefaultBehavior: boolean = false): number {
     // override default behavior if all bits are false
-    if (overrideDefaultBehavior && bits.every((bit) => !bit)) return -1;
+    if (overrideDefaultBehavior && bits.every((bit) => !bit)) {
+      return -1;
+    }
 
     let result = 0;
 


### PR DESCRIPTION
Closes #3239

It's possible to override the default behavior for the flag selector now. If the behavior is overridden, it defaults to -1 when all bits are unset. Otherwise everything stays the same.