### PR TITLE
feat: SQL Editor - Syntax Coloring

### DIFF
--- a/apps/keira/src/assets/i18n/de.json
+++ b/apps/keira/src/assets/i18n/de.json
@@ -255,7 +255,7 @@
       "DETECTION_RANGE": "Steuert den Bereich, in dem Kreaturen Spieler erkennen und sehen.",
       "ITEMID1": "Dies ist die Gegenstandsnummer der Ausrüstung, die in der rechten Hand aus Item.dbc verwendet wird.",
       "ITEMID2": "Dies ist die Gegenstandsnummer der Ausrüstung, die in der linken Hand aus Item.dbc verwendet wird.",
-      "ITEMID3": "Dies ist die Gegenstandsnummer der Ausrüstung, die im Fernkampf-Slot aus Item.dbc verwendet wird.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc.",
       "FactionHint": "When refering to the Creature's Faction ID it's the column on the left 'ID' in the selector, more information check 'faction' in the wiki."
     },
     "TEMPLATE_ADDON": {

--- a/libs/features/sql-editor/src/sql-editor.component.html
+++ b/libs/features/sql-editor/src/sql-editor.component.html
@@ -13,7 +13,15 @@
       </div>
     </div>
 
-    <textarea id="code" class="mb-1" [(ngModel)]="service.code" (keydown.f9)="execute()" rows="6" spellcheck="false"></textarea>
+    <code-editor
+      id="code"
+      [lineWrapping]="true"
+      (keydown.f9)="execute()"
+      [languages]="languages"
+      [language]="'MySQL'"
+      [setup]="'basic'"
+      [(ngModel)]="service.code"
+    />
 
     <div class="row">
       <div class="col-sm-7">

--- a/libs/features/sql-editor/src/sql-editor.component.html
+++ b/libs/features/sql-editor/src/sql-editor.component.html
@@ -15,6 +15,7 @@
 
     <code-editor
       id="code"
+      [extensions]="extensions"
       [lineWrapping]="true"
       (keydown.f9)="execute()"
       [languages]="languages"

--- a/libs/features/sql-editor/src/sql-editor.component.scss
+++ b/libs/features/sql-editor/src/sql-editor.component.scss
@@ -1,11 +1,6 @@
 #code {
-  width: 100%;
-  padding: 9.5px;
-  word-break: break-all;
-  word-wrap: break-word;
-  background-color: #f5f5f5;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  resize: vertical;
+  margin-bottom: 1rem;
 }
 
 .select-limit {

--- a/libs/features/sql-editor/src/sql-editor.component.scss
+++ b/libs/features/sql-editor/src/sql-editor.component.scss
@@ -1,6 +1,14 @@
 #code {
+  overflow: auto;
   resize: vertical;
+  min-height: calc(1.5em * 6);
   margin-bottom: 1rem;
+  border: 1px solid #e49649;
+  border-radius: 0.25rem;
+}
+
+#code ::ng-deep .cm-editor {
+  outline: none; // remove the default outline
 }
 
 .select-limit {

--- a/libs/features/sql-editor/src/sql-editor.component.ts
+++ b/libs/features/sql-editor/src/sql-editor.component.ts
@@ -16,6 +16,7 @@ import { MysqlQueryService } from '@keira/shared/db-layer';
 import { CodeEditor } from '@acrodata/code-editor';
 import { LanguageDescription } from '@codemirror/language';
 import { MySQL, sql } from '@codemirror/lang-sql';
+import { githubLight } from '@uiw/codemirror-theme-github';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -34,7 +35,8 @@ export class SqlEditorComponent extends SubscriptionHandler {
   readonly docUrl = 'https://www.w3schools.com/sql/sql_intro.asp';
   private readonly MAX_COL_SHOWN = 20;
 
-  languages = [LanguageDescription.of({ name: 'MySQL', support: sql({ dialect: MySQL }) })];
+  languages = [LanguageDescription.of({ name: 'MySQL', support: sql({ dialect: MySQL, upperCaseKeywords: true }) })];
+  extensions = [githubLight];
 
   private _error: QueryError | undefined;
   get error(): QueryError | undefined {

--- a/libs/features/sql-editor/src/sql-editor.component.ts
+++ b/libs/features/sql-editor/src/sql-editor.component.ts
@@ -13,12 +13,16 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { QueryErrorComponent } from '@keira/shared/base-editor-components';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 
+import { CodeEditor } from '@acrodata/code-editor';
+import { LanguageDescription } from '@codemirror/language';
+import { MySQL, sql } from '@codemirror/lang-sql';
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-sql-editor',
   templateUrl: './sql-editor.component.html',
   styleUrls: ['./sql-editor.component.scss'],
-  imports: [TooltipModule, FormsModule, QueryErrorComponent, NgxDatatableModule, TranslateModule],
+  imports: [CodeEditor, TooltipModule, FormsModule, QueryErrorComponent, NgxDatatableModule, TranslateModule],
 })
 export class SqlEditorComponent extends SubscriptionHandler {
   private readonly mysqlQueryService = inject(MysqlQueryService);
@@ -29,6 +33,8 @@ export class SqlEditorComponent extends SubscriptionHandler {
   readonly DTCFG = DTCFG;
   readonly docUrl = 'https://www.w3schools.com/sql/sql_intro.asp';
   private readonly MAX_COL_SHOWN = 20;
+
+  languages = [LanguageDescription.of({ name: 'MySQL', support: sql({ dialect: MySQL }) })];
 
   // displayLimit = 10;
   // get displayLimitOptions() {

--- a/libs/features/sql-editor/src/sql-editor.component.ts
+++ b/libs/features/sql-editor/src/sql-editor.component.ts
@@ -36,11 +36,6 @@ export class SqlEditorComponent extends SubscriptionHandler {
 
   languages = [LanguageDescription.of({ name: 'MySQL', support: sql({ dialect: MySQL }) })];
 
-  // displayLimit = 10;
-  // get displayLimitOptions() {
-  //   return [10, 20, 50, 100, 200, 500, 1000];
-  // }
-
   private _error: QueryError | undefined;
   get error(): QueryError | undefined {
     return this._error;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@ngx-translate/core": "16.0.4",
         "@ngx-translate/http-loader": "16.0.1",
         "@types/electron-settings": "4.0.2",
+        "@uiw/codemirror-theme-github": "^4.23.12",
         "acorn": "8.14.1",
         "body-parser": "1.20.2",
         "cors": "2.8.5",
@@ -10312,6 +10313,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-github": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-github/-/codemirror-theme-github-4.23.12.tgz",
+      "integrity": "sha512-yxgycQxA1fNVdrjIZ7H7pq+9Q+BeKLmD5oq5oOlw7kVJrnToOMBylv5oIWplVd2s2LFo47lIhWrVC9Ay3b6Baw==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.23.12"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-themes": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.23.12.tgz",
+      "integrity": "sha512-8etEByfS9yttFZW0rcWhdZc7/JXJKRWlU5lHmJCI3GydZNGCzydNA+HtK9nWKpJUndVc58Q2sqSC5OIcwq8y6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "3.8.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@acrodata/code-editor": "^0.5.1",
+        "@codemirror/lang-sql": "^6.8.0",
         "@ngx-translate/core": "16.0.4",
         "@ngx-translate/http-loader": "16.0.1",
         "@types/electron-settings": "4.0.2",
@@ -112,6 +114,22 @@
         "@nx/nx-darwin-x64": "20.8.1",
         "@nx/nx-linux-x64-gnu": "20.8.1",
         "@nx/nx-win32-x64-msvc": "20.8.1"
+      }
+    },
+    "node_modules/@acrodata/code-editor": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@acrodata/code-editor/-/code-editor-0.5.1.tgz",
+      "integrity": "sha512-ta0prFRwXQgLSqBtjzpR9+eWXPpFh/+tS/BQapoA89cMnJDo6zCjkfEax41uO5xb96UJA3IAuYM22jUA6G4WRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/merge": "^6.0.0",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "codemirror": "^6.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=16.0.0",
+        "@angular/forms": ">=16.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2987,6 +3005,125 @@
       "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.18.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
+      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+      "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.8.0.tgz",
+      "integrity": "sha512-aGLmY4OwGqN3TdSx3h6QeA1NrvaYtF7kkoWR/+W7/JzB0gQtJ+VJxewlnE3+VImhA4WVlhmkJr109PefOOhjLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.0.tgz",
+      "integrity": "sha512-A7+f++LodNNc1wGgoRDTt78cOwWm9KVezApgjOMp1W4hM0898nsqBXwF+sbePE7ZRcjN7Sa1Z5m2oN27XkmEjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/merge": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.10.1.tgz",
+      "integrity": "sha512-TgZD+LDa2EIeqTkptg42TAU6n3meq++rQC+e7FuCi1arEm8CRGVQw5Fygb7UIfDzFAt4QrE6SS3CPOz06D2ALg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/highlight": "^1.0.0",
+        "style-mod": "^4.1.0"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.2.tgz",
+      "integrity": "sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.36.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.8.tgz",
+      "integrity": "sha512-yoRo4f+FdnD01fFt4XpfpMCcCAo9QvZOtbrXExn4SqzH32YC6LgzqxfLZw/r6Ge65xyY03mK/UfUqrVw1gFiFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -4505,6 +4642,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.2.6.tgz",
@@ -4627,6 +4788,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@modern-js/node-bundle-require": {
       "version": "2.65.1",
@@ -12171,6 +12338,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -12982,6 +13164,12 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
     "node_modules/cron-parser": {
@@ -25588,6 +25776,12 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "license": "MIT"
+    },
     "node_modules/stylehacks": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
@@ -27078,6 +27272,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/wait-on": {
       "version": "8.0.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@ngx-translate/core": "16.0.4",
     "@ngx-translate/http-loader": "16.0.1",
     "@types/electron-settings": "4.0.2",
+    "@uiw/codemirror-theme-github": "^4.23.12",
     "acorn": "8.14.1",
     "body-parser": "1.20.2",
     "cors": "2.8.5",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@acrodata/code-editor": "^0.5.1",
+    "@codemirror/lang-sql": "^6.8.0",
     "@ngx-translate/core": "16.0.4",
     "@ngx-translate/http-loader": "16.0.1",
     "@types/electron-settings": "4.0.2",


### PR DESCRIPTION
Adds SQL syntax with MySQL dialect and upper case auto completions. Highlighting uses the github light theme to match the existing HighlightJS highlighting

## new dependencies

TLDR;
> Highlight.js really isn't intended to be used as a live code editor.
https://stackoverflow.com/questions/19346975/highlight-js-in-textarea
https://github.com/highlightjs/highlight.js/issues/1356

CodeMirror 6 wrapper for Angular
https://github.com/acrodata/code-editor

CodeMirror https://codemirror.net

sql lang support https://www.npmjs.com/package/@codemirror/lang-sql

CodeMirror github theme https://www.npmjs.com/package/@uiw/codemirror-theme-github

## Closes

continuation of 
- https://github.com/azerothcore/Keira3/pull/3173

- Closes https://github.com/azerothcore/Keira3/issues/3131

## How to test
- F9 button
- copy button
- resizing bottom right corner
- mouse over highlighting and copying

## other libs for reference
❌ [monaco](https://github.com/miki995/ngx-monaco-editor-v2): electronjs struggled with asset imports
❌ [ace](https://github.com/zefoy/ngx-ace-wrapper): soon to be or already deprecated for newer Angular versions
