### PR TITLE
feat: integrate Unused-Guid-Search

### DIFF
--- a/apps/keira/src/app/routes.ts
+++ b/apps/keira/src/app/routes.ts
@@ -94,6 +94,7 @@ import {
   SelectAcoreStringComponent,
 } from 'texts';
 import { GameTeleComponent, GameTeleHandlerService, SelectGameTeleComponent } from '@keira/features/game-tele';
+import { UnusedGuidSearchComponent } from '@keira/features/unused-guid-search';
 
 export const KEIRA_ROUTES: Routes = [
   {
@@ -504,5 +505,9 @@ export const KEIRA_ROUTES: Routes = [
         canActivate: [GameTeleHandlerService],
       },
     ],
+  },
+  {
+    path: 'unused-guid-search',
+    component: UnusedGuidSearchComponent,
   },
 ];

--- a/apps/keira/src/assets/i18n/de.json
+++ b/apps/keira/src/assets/i18n/de.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Willkommen bei Keira3",
@@ -255,7 +256,7 @@
       "DETECTION_RANGE": "Steuert den Bereich, in dem Kreaturen Spieler erkennen und sehen.",
       "ITEMID1": "Dies ist die Gegenstandsnummer der Ausrüstung, die in der rechten Hand aus Item.dbc verwendet wird.",
       "ITEMID2": "Dies ist die Gegenstandsnummer der Ausrüstung, die in der linken Hand aus Item.dbc verwendet wird.",
-      "ITEMID3": "Dies ist die Gegenstandsnummer der Ausrüstung, die im Fernkampf-Slot aus Item.dbc verwendet wird.",
+      "ItemID3": "This is the item number of the equipment used in the ranged slot from Item.dbc.",
       "FactionHint": "When refering to the Creature's Faction ID it's the column on the left 'ID' in the selector, more information check 'faction' in the wiki."
     },
     "TEMPLATE_ADDON": {

--- a/apps/keira/src/assets/i18n/el.json
+++ b/apps/keira/src/assets/i18n/el.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Welcome to Keira3",

--- a/apps/keira/src/assets/i18n/en.json
+++ b/apps/keira/src/assets/i18n/en.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Welcome to Keira3",

--- a/apps/keira/src/assets/i18n/es.json
+++ b/apps/keira/src/assets/i18n/es.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Bienvenido a Keira3",

--- a/apps/keira/src/assets/i18n/fr.json
+++ b/apps/keira/src/assets/i18n/fr.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Welcome to Keira3",

--- a/apps/keira/src/assets/i18n/it.json
+++ b/apps/keira/src/assets/i18n/it.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Welcome to Keira3",

--- a/apps/keira/src/assets/i18n/ko.json
+++ b/apps/keira/src/assets/i18n/ko.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Welcome to Keira3",

--- a/apps/keira/src/assets/i18n/nl.json
+++ b/apps/keira/src/assets/i18n/nl.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Welcome to Keira3",

--- a/apps/keira/src/assets/i18n/pl.json
+++ b/apps/keira/src/assets/i18n/pl.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Welcome to Keira3",

--- a/apps/keira/src/assets/i18n/pt.json
+++ b/apps/keira/src/assets/i18n/pt.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Bem-vindo(a) a Keira3!",

--- a/apps/keira/src/assets/i18n/ro.json
+++ b/apps/keira/src/assets/i18n/ro.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Welcome to Keira3",

--- a/apps/keira/src/assets/i18n/ru.json
+++ b/apps/keira/src/assets/i18n/ru.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Добро пожаловать в Keira3",

--- a/apps/keira/src/assets/i18n/sk.json
+++ b/apps/keira/src/assets/i18n/sk.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Welcome to Keira3",

--- a/apps/keira/src/assets/i18n/sv.json
+++ b/apps/keira/src/assets/i18n/sv.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "Välkommen till Keira3",

--- a/apps/keira/src/assets/i18n/zh.json
+++ b/apps/keira/src/assets/i18n/zh.json
@@ -179,7 +179,8 @@
       "TITLE": "Game Teleport",
       "SEARCH_GAME_TELE": "Search Teleport",
       "SELECT_GAME_TELE": "Game Tele Editor"
-    }
+    },
+    "UNUSED_GUID_SEARCH": "Unused GUIDs"
   },
   "DASHBOARD": {
     "WELCOME": "欢迎使用Keira3",

--- a/libs/features/unused-guid-search/.eslintrc.json
+++ b/libs/features/unused-guid-search/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "keira",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "keira",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/features/unused-guid-search/README.md
+++ b/libs/features/unused-guid-search/README.md
@@ -1,0 +1,3 @@
+# keira-features-unused-guid-search
+
+This library was generated with [Nx](https://nx.dev).

--- a/libs/features/unused-guid-search/project.json
+++ b/libs/features/unused-guid-search/project.json
@@ -1,0 +1,25 @@
+{
+  "name": "keira-features-unused-guid-search",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/features/unused-guid-search/src",
+  "prefix": "keira",
+  "projectType": "library",
+  "tags": ["scope:features"],
+  "targets": {
+    "test": {
+      "executor": "@angular-devkit/build-angular:karma",
+      "options": {
+        "tsConfig": "libs/features/unused-guid-search/tsconfig.spec.json",
+        "karmaConfig": "libs/features/game-tele/karma.conf.js",
+        "polyfills": ["zone.js", "zone.js/testing"],
+        "sourceMap": true,
+        "codeCoverage": true,
+        "styles": ["apps/keira/src/app/scss/main-test.scss"],
+        "scripts": ["node_modules/squel/dist/squel.min.js"]
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/features/unused-guid-search/src/index.ts
+++ b/libs/features/unused-guid-search/src/index.ts
@@ -1,0 +1,1 @@
+export * from './unused-guid-search.component';

--- a/libs/features/unused-guid-search/src/unused-guid-search.component.html
+++ b/libs/features/unused-guid-search/src/unused-guid-search.component.html
@@ -1,0 +1,58 @@
+<div class="container-fluid">
+  <div class="content-block">
+    <form (ngSubmit)="onSearch()" #guidForm="ngForm" class="mb-3">
+      <div class="form-group row">
+        <label class="col-sm-2 col-form-label">Table</label>
+        <div class="col-sm-4">
+          <select class="form-control" [(ngModel)]="selectedDb" name="selectedDb" required>
+            @for (db of dbOptions; track db) {
+              <option [ngValue]="db" [label]="db.label"></option>
+            }
+          </select>
+        </div>
+      </div>
+      <div class="form-group row mt-2">
+        <label class="col-sm-2 col-form-label">Start Index</label>
+        <div class="col-sm-4">
+          <input
+            type="number"
+            class="form-control"
+            [(ngModel)]="startIndex"
+            name="startIndex"
+            min="1"
+            [max]="MAX_INT_UNSIGNED_VALUE"
+            required
+          />
+        </div>
+      </div>
+      <div class="form-group row mt-2">
+        <label class="col-sm-2 col-form-label">Amount</label>
+        <div class="col-sm-4">
+          <input type="number" class="form-control" [(ngModel)]="amount" name="amount" min="1" [max]="MAX_INT_UNSIGNED_VALUE" required />
+        </div>
+      </div>
+      <div class="form-group row mt-2">
+        <label class="col-sm-2 col-form-label">Consecutive</label>
+        <div class="col-sm-4 d-flex align-items-center">
+          <input type="checkbox" [(ngModel)]="consecutive" name="consecutive" />
+        </div>
+      </div>
+      <div class="form-group row mt-3">
+        <div class="col-sm-6">
+          <button class="btn btn-primary" type="submit" [disabled]="loading">Search</button>
+        </div>
+      </div>
+    </form>
+
+    @if (loading) {
+      <div class="alert alert-info">Searching...</div>
+    }
+    @if (error) {
+      <div class="alert alert-danger">{{ error }}</div>
+    }
+    @if (results.length > 0) {
+      <div class="alert alert-success">Found unused GUIDs:</div>
+      <textarea id="results" class="mb-1" [value]="results.join(', ')" rows="6" spellcheck="false" readonly></textarea>
+    }
+  </div>
+</div>

--- a/libs/features/unused-guid-search/src/unused-guid-search.component.scss
+++ b/libs/features/unused-guid-search/src/unused-guid-search.component.scss
@@ -1,0 +1,9 @@
+#results {
+  width: 100%;
+  padding: 9.5px;
+  word-break: break-all;
+  word-wrap: break-word;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}

--- a/libs/features/unused-guid-search/src/unused-guid-search.component.ts
+++ b/libs/features/unused-guid-search/src/unused-guid-search.component.ts
@@ -1,0 +1,134 @@
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { CommonModule } from '@angular/common';
+import { MysqlQueryService } from '@keira/shared/db-layer';
+import { firstValueFrom } from 'rxjs';
+import {
+  CREATURE_SPAWN_TABLE,
+  CREATURE_SPAWN_ID_2,
+  GAMEOBJECT_SPAWN_TABLE,
+  GAMEOBJECT_SPAWN_ID_2,
+  CREATURE_TEMPLATE_TABLE,
+  CREATURE_TEMPLATE_ID,
+  GAMEOBJECT_TEMPLATE_TABLE,
+  GAMEOBJECT_TEMPLATE_ID,
+  GOSSIP_MENU_TABLE,
+  GOSSIP_MENU_ID,
+  NPC_TEXT_TABLE,
+  NPC_TEXT_ID,
+  PAGE_TEXT_TABLE,
+  PAGE_TEXT_ID,
+  ACORE_STRING_TABLE,
+  ACORE_STRING_ENTRY,
+} from '@keira/shared/acore-world-model';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'keira-features-unused-guid-search',
+  templateUrl: './unused-guid-search.component.html',
+  styleUrl: './unused-guid-search.component.scss',
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, TranslateModule],
+})
+export class UnusedGuidSearchComponent {
+  readonly MAX_INT_UNSIGNED_VALUE = 4294967295;
+
+  dbOptions = [
+    { table: CREATURE_SPAWN_TABLE, key: CREATURE_SPAWN_ID_2, label: `${CREATURE_SPAWN_TABLE} (${CREATURE_SPAWN_ID_2})` },
+    { table: GAMEOBJECT_SPAWN_TABLE, key: GAMEOBJECT_SPAWN_ID_2, label: `${GAMEOBJECT_SPAWN_TABLE} (${GAMEOBJECT_SPAWN_ID_2})` },
+    { table: CREATURE_TEMPLATE_TABLE, key: CREATURE_TEMPLATE_ID, label: `${CREATURE_TEMPLATE_TABLE} (${CREATURE_TEMPLATE_ID})` },
+    { table: GAMEOBJECT_TEMPLATE_TABLE, key: GAMEOBJECT_TEMPLATE_ID, label: `${GAMEOBJECT_TEMPLATE_TABLE} (${GAMEOBJECT_TEMPLATE_ID})` },
+    { table: GOSSIP_MENU_TABLE, key: GOSSIP_MENU_ID, label: `${GOSSIP_MENU_TABLE} (${GOSSIP_MENU_ID})` },
+    { table: NPC_TEXT_TABLE, key: NPC_TEXT_ID, label: `${NPC_TEXT_TABLE} (${NPC_TEXT_ID})` },
+    { table: PAGE_TEXT_TABLE, key: PAGE_TEXT_ID, label: `${PAGE_TEXT_TABLE} (${PAGE_TEXT_ID})` },
+    { table: ACORE_STRING_TABLE, key: ACORE_STRING_ENTRY, label: `${ACORE_STRING_TABLE} (${ACORE_STRING_ENTRY})` },
+    { table: 'waypoint_scripts', key: 'id', label: 'waypoint_scripts (id)' },
+    { table: 'pool_template', key: 'entry', label: 'pool_template (entry)' },
+    { table: 'game_event', key: 'eventEntry', label: 'game_event (eventEntry)' },
+  ];
+  selectedDb = this.dbOptions[0];
+  results: string[] = [];
+  loading = false;
+  error = '';
+  consecutive = false;
+  amount = 10;
+  startIndex = 1;
+
+  constructor(
+    private mysql: MysqlQueryService,
+    private cdr: ChangeDetectorRef,
+  ) {}
+
+  async onSearch() {
+    this.error = '';
+
+    if (
+      this.startIndex < 1 ||
+      this.amount < 1 ||
+      this.startIndex > this.MAX_INT_UNSIGNED_VALUE ||
+      this.amount > this.MAX_INT_UNSIGNED_VALUE
+    ) {
+      this.error = `Start Index and Amount must be safe integers between 1 and ${this.MAX_INT_UNSIGNED_VALUE}.`;
+      return;
+    }
+
+    this.results = [];
+    this.loading = true;
+    try {
+      // Fetch all existing GUIDs
+      const rows = await firstValueFrom(
+        this.mysql.query<{ guid: number }>(
+          `SELECT ${this.selectedDb.key} AS guid FROM ${this.selectedDb.table} WHERE ${this.selectedDb.key} >= ${this.startIndex}`,
+        ),
+      );
+      const usedGuids = new Set(rows.map((r) => Number(r.guid)));
+
+      // Find unused GUIDs
+      const found: number[] = [];
+      let current = this.startIndex;
+      if (this.consecutive) {
+        let streak = 0;
+        let streakStart = current;
+        while (found.length < this.amount) {
+          if (!usedGuids.has(current)) {
+            streak++;
+            if (streak === 1) {
+              streakStart = current;
+            }
+            if (streak === this.amount) {
+              for (let i = 0; i < this.amount; i++) {
+                found.push(streakStart + i);
+              }
+              break;
+            }
+          } else {
+            streak = 0;
+          }
+          current++;
+          if (current >= this.MAX_INT_UNSIGNED_VALUE) {
+            break;
+          }
+        }
+      } else {
+        while (found.length < this.amount) {
+          if (!usedGuids.has(current)) {
+            found.push(current);
+          }
+          current++;
+          if (current >= this.MAX_INT_UNSIGNED_VALUE) {
+            break;
+          }
+        }
+      }
+      this.results = found.map(String);
+      if (found.length < this.amount) {
+        this.error = `Only found ${found.length} unused GUIDs.`;
+      }
+    } catch (e: any) {
+      this.error = e?.message || 'Error searching for unused GUIDs';
+    } finally {
+      this.loading = false;
+      this.cdr.markForCheck();
+    }
+  }
+}

--- a/libs/features/unused-guid-search/tsconfig.json
+++ b/libs/features/unused-guid-search/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/features/unused-guid-search/tsconfig.lib.json
+++ b/libs/features/unused-guid-search/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/**/*.spec.ts", "jest.config.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/main/main-window/src/sidebar/sidebar.component.html
+++ b/libs/main/main-window/src/sidebar/sidebar.component.html
@@ -762,6 +762,12 @@
               </ul>
             </div>
           </li>
+
+          <li>
+            <a id="unused-guid-search" href="#" [routerLink]="'unused-guid-search'">
+              <i class="fa fa-search"></i> {{ 'SIDEBAR.UNUSED_GUID_SEARCH' | translate }}
+            </a>
+          </li>
         </ul>
       </div>
     </div>

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -37,6 +37,7 @@
       "@keira/features/spell": ["libs/features/spell/src/index.ts"],
       "@keira/features/sql-editor": ["libs/features/sql-editor/src/index.ts"],
       "@keira/features/texts": ["libs/features/texts/src/index.ts"],
+      "@keira/features/unused-guid-search": ["libs/features/unused-guid-search/src/index.ts"],
       "@keira/main/connection-window": ["libs/main/connection-window/src/index.ts"],
       "@keira/main/main-window": ["libs/main/main-window/src/index.ts"],
       "@keira/shared/acore-world-model": ["libs/shared/acore-world-model/src/index.ts"],
@@ -55,6 +56,7 @@
       "@keira/shared/switch-language": ["libs/shared/switch-language/src/index.ts"],
       "@keira/shared/test-utils": ["libs/shared/test-utils/src/index.ts"],
       "@keira/shared/utils": ["libs/shared/utils/src/index.ts"],
+      "keira-features-unused-guid-search": ["libs/features/unused-guid-search/src/index.ts"],
       "texts": ["libs/features/texts/src/index.ts"]
     },
     "rootDir": "."


### PR DESCRIPTION
This integrates https://github.com/Kitzunu/Unused-Guid-Search as a tab

<details><summary>UI Screenshot</summary>

![keira3_unused](https://github.com/user-attachments/assets/418d4a75-b7f1-4cb2-a065-80e71244f6fb)


</details>


I copied the minimal UI, and the feature supports the same tables
- UI https://github.com/Kitzunu/Unused-Guid-Search/blob/master/guid2.PNG
- tables https://github.com/Kitzunu/Unused-Guid-Search/blob/aef451e81e6c1333bd89535f41d4ed4b9931372f/UnusedGuidSearcher/SearchGuids.cs#L13

It's still missing tests and translations, but I would prefer some feedback before, as I'm not too familiar with Angular architecture