### PR TITLE
fix(SAI): ACTION_38_SET_IN_COMBAT_WITH_ZONE tooltip + removed unused param

### DIFF
--- a/libs/shared/sai-editor/src/constants/sai-actions.ts
+++ b/libs/shared/sai-editor/src/constants/sai-actions.ts
@@ -454,10 +454,7 @@ SAI_ACTION_PARAM1_TOOLTIPS[SAI_ACTIONS.DIE] =
 
 // SMART_ACTION_SET_IN_COMBAT_WITH_ZONE
 SAI_ACTION_TOOLTIPS[SAI_ACTIONS.SET_IN_COMBAT_WITH_ZONE] =
-  'Sets the creature in combat with its zone, can be used in instances and open world. Useful for creatures inside instances so all players will be set in combat until the fight ends. It only sets NPCs in combat with players';
-SAI_ACTION_PARAM1_NAMES[SAI_ACTIONS.SET_IN_COMBAT_WITH_ZONE] = 'Range';
-SAI_ACTION_PARAM1_TOOLTIPS[SAI_ACTIONS.SET_IN_COMBAT_WITH_ZONE] =
-  'Range in yards for all players to be forced into combat with the creature. Only used in the open world. Leave as 0 if used in an instance.';
+  'Sets the creature in combat with its zone, can be used in instances and open world. Useful for creatures inside instances so all players will be set in combat until the fight ends. It only sets NPCs in combat with players, this only works with the target_type 9 - CREATURE_RANGE';
 
 // SMART_ACTION_CALL_FOR_HELP
 SAI_ACTION_TOOLTIPS[SAI_ACTIONS.CALL_FOR_HELP] =


### PR DESCRIPTION
ACTION_38_SET_IN_COMBAT_WITH_ZONE does not any params for range, it uses the target and only target type 9 (creature_range)

From:
action info
![image](https://github.com/user-attachments/assets/5de8ec45-edfd-4a45-bf11-f69849c47377)

action param1 info
![image](https://github.com/user-attachments/assets/105cefae-bbf2-4a54-8ff3-eaf1513897f6)


To:
action info
![image](https://github.com/user-attachments/assets/5e388679-4d97-41aa-98fa-2d0731c69529)


Refer to this: https://discord.com/channels/217589275766685707/536630256048799744/1385621105070575616 in the AC discord