### PR TITLE
Refactor unit tests to avoid shared variables

### DIFF
--- a/libs/features/gameobject/src/gameobject-template-addon/gameobject-template-addon.integration.spec.ts
+++ b/libs/features/gameobject/src/gameobject-template-addon/gameobject-template-addon.integration.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
@@ -16,11 +16,6 @@ import { instance, mock } from 'ts-mockito';
 class GameobjectTemplateAddonPage extends EditorPageObject<GameobjectTemplateAddonComponent> {}
 
 describe('GameobjectTemplateAddon integration tests', () => {
-  let fixture: ComponentFixture<GameobjectTemplateAddonComponent>;
-  let queryService: MysqlQueryService;
-  let querySpy: Spy;
-  let handlerService: GameobjectHandlerService;
-  let page: GameobjectTemplateAddonPage;
 
   const id = 1234;
   const expectedFullCreateQuery =
@@ -54,31 +49,33 @@ describe('GameobjectTemplateAddon integration tests', () => {
   }));
 
   function setup(creatingNew: boolean) {
-    handlerService = TestBed.inject(GameobjectHandlerService);
+    const handlerService = TestBed.inject(GameobjectHandlerService);
     handlerService['_selected'] = `${id}`;
     handlerService.isNew = creatingNew;
 
-    queryService = TestBed.inject(MysqlQueryService);
-    querySpy = spyOn(queryService, 'query').and.returnValue(of([]));
+    const queryService = TestBed.inject(MysqlQueryService);
+    const querySpy = spyOn(queryService, 'query').and.returnValue(of([]));
 
     spyOn(queryService, 'selectAll').and.returnValue(of(creatingNew ? [] : [originalEntity]));
 
-    fixture = TestBed.createComponent(GameobjectTemplateAddonComponent);
-    page = new GameobjectTemplateAddonPage(fixture);
+    const fixture = TestBed.createComponent(GameobjectTemplateAddonComponent);
+    const page = new GameobjectTemplateAddonPage(fixture);
     fixture.autoDetectChanges(true);
     fixture.detectChanges();
+
+    return { handlerService, queryService, querySpy, fixture, page };
   }
 
   describe('Creating new', () => {
-    beforeEach(() => setup(true));
-
     it('should correctly initialise', () => {
+      const { page } = setup(true);
       page.expectQuerySwitchToBeHidden();
       page.expectFullQueryToBeShown();
       page.expectFullQueryToContain(expectedFullCreateQuery);
     });
 
     it('should correctly update the unsaved status', () => {
+      const { page, handlerService } = setup(true);
       const field = 'faction';
       expect(handlerService.isGameobjectTemplateAddonUnsaved).toBe(false);
       page.setInputValueById(field, 3);
@@ -88,6 +85,7 @@ describe('GameobjectTemplateAddon integration tests', () => {
     });
 
     it('changing a property and executing the query should correctly work', () => {
+      const { page, querySpy } = setup(true);
       const expectedQuery =
         'DELETE FROM `gameobject_template_addon` WHERE (`entry` = ' +
         id +
@@ -110,15 +108,15 @@ describe('GameobjectTemplateAddon integration tests', () => {
   });
 
   describe('Editing existing', () => {
-    beforeEach(() => setup(false));
-
     it('should correctly initialise', () => {
+      const { page } = setup(false);
       page.expectDiffQueryToBeShown();
       page.expectDiffQueryToBeEmpty();
       page.expectFullQueryToContain(expectedFullCreateQuery);
     });
 
     it('changing all properties and executing the query should correctly work', () => {
+      const { page, querySpy } = setup(false);
       const expectedQuery =
         'UPDATE `gameobject_template_addon` SET ' +
         '`flags` = 1, `mingold` = 2, `maxgold` = 3, `artkit0` = 4, `artkit1` = 5, `artkit2` = 6, `artkit3` = 7 WHERE (`entry` = ' +
@@ -136,6 +134,7 @@ describe('GameobjectTemplateAddon integration tests', () => {
     });
 
     it('changing values should correctly update the queries', () => {
+      const { page } = setup(false);
       page.setInputValueById('faction', '35');
       page.expectDiffQueryToContain('UPDATE `gameobject_template_addon` SET `faction` = 35 WHERE (`entry` = ' + id + ');');
       page.expectFullQueryToContain('35');

--- a/libs/shared/base-editor-components/src/create/create.component.spec.ts
+++ b/libs/shared/base-editor-components/src/create/create.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { MockHandlerService } from '@keira/shared/base-abstract-classes';
@@ -23,12 +23,6 @@ class CreateComponentPage extends PageObject<CreateComponent<TableRow>> {
 }
 
 describe('CreateComponent', () => {
-  let component: CreateComponent<TableRow>;
-  let fixture: ComponentFixture<CreateComponent<TableRow>>;
-  let page: CreateComponentPage;
-  let spyError: Spy;
-  let MockedMysqlQueryService: any;
-
   const mockTable = 'mock_table';
   const mockId = 'mockId';
   const takenId = 100;
@@ -36,38 +30,42 @@ describe('CreateComponent', () => {
   const MAX_INT_UNSIGNED_VALUE = 4294967295;
 
   beforeEach(waitForAsync(() => {
-    spyError = spyOn(console, 'error');
-
     TestBed.configureTestingModule({
       imports: [BrowserModule, FormsModule, TranslateTestingModule, CreateComponent],
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    MockedMysqlQueryService = mock(MysqlQueryService);
+  function setup() {
+    const spyError = spyOn(console, 'error');
+
+    const MockedMysqlQueryService = mock(MysqlQueryService);
     when(MockedMysqlQueryService.getMaxId(mockTable, mockId)).thenReturn(of([{ max: maxId }]));
     when(MockedMysqlQueryService.selectAll(mockTable, mockId, anything())).thenReturn(of([]));
     when(MockedMysqlQueryService.selectAll(mockTable, mockId, takenId)).thenReturn(of([{}]));
 
-    fixture = TestBed.createComponent(CreateComponent);
-    component = fixture.componentInstance;
+    const fixture = TestBed.createComponent(CreateComponent);
+    const component = fixture.componentInstance;
     component.entityTable = mockTable;
     component.entityIdField = mockId;
     component.handlerService = instance(mock(MockHandlerService));
     component.queryService = instance(MockedMysqlQueryService);
     component.maxEntryValue = MAX_INT_UNSIGNED_VALUE;
-    page = new CreateComponentPage(fixture);
+    const page = new CreateComponentPage(fixture);
     fixture.autoDetectChanges(true);
     fixture.detectChanges();
-  });
+
+    return { component, fixture, page, spyError, MockedMysqlQueryService };
+  }
 
   it('should display the next id by default', waitForAsync(async () => {
+    const { fixture, page, component } = setup();
     await fixture.whenStable();
     expect(page.idInput.value).toEqual(`${maxId + 1}`);
     expect(component.loading).toBe(false);
   }));
 
   it('should correctly toggle id free status the message', () => {
+    const { page, component } = setup();
     page.setInputValue(page.idInput, takenId);
     expect(page.idFreeStatusBox.innerHTML).toContain('CREATE.ALREADY_USE');
 
@@ -78,6 +76,7 @@ describe('CreateComponent', () => {
   });
 
   it('should correctly show console errors if any', () => {
+    const { component, MockedMysqlQueryService, spyError } = setup();
     reset(MockedMysqlQueryService);
     when(MockedMysqlQueryService.getMaxId(mockTable, mockId)).thenReturn(throwError('error'));
     when(MockedMysqlQueryService.selectAll(mockTable, mockId, anything())).thenReturn(throwError('error'));
@@ -90,6 +89,7 @@ describe('CreateComponent', () => {
   });
 
   it('if queryService param is not passed, should not call getNextId', () => {
+    const { component } = setup();
     const spyGetNextId = spyOn<any>(component, 'getNextId');
     component.queryService = undefined as any;
 
@@ -99,6 +99,7 @@ describe('CreateComponent', () => {
   });
 
   it('clicking the button should correctly trigger the selection', () => {
+    const { page, component } = setup();
     const selectSpy = spyOn(component.handlerService, 'select');
     const id = 1234;
     page.setInputValue(page.idInput, id);
@@ -110,6 +111,7 @@ describe('CreateComponent', () => {
   });
 
   it('does not allow a higher value than max value', () => {
+    const { component } = setup();
     const unallowedIdValue = MAX_INT_UNSIGNED_VALUE + 1;
     component.idModel = unallowedIdValue;
 
@@ -119,6 +121,7 @@ describe('CreateComponent', () => {
   });
 
   it('the customStartId should be preferred when greater than the currentMax', () => {
+    const { component } = setup();
     component.customStartingId = 10;
     expect(component['calculateNextId'](5)).toEqual(10);
   });

--- a/libs/shared/base-editor-components/src/highlightjs-wrapper/highlightjs-wrapper.component.spec.ts
+++ b/libs/shared/base-editor-components/src/highlightjs-wrapper/highlightjs-wrapper.component.spec.ts
@@ -1,26 +1,25 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { HighlightjsWrapperComponent } from './highlightjs-wrapper.component';
 
 describe('HighlightjsWrapperComponent', () => {
-  let component: HighlightjsWrapperComponent;
-  let fixture: ComponentFixture<HighlightjsWrapperComponent>;
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [BrowserModule, FormsModule, HighlightjsWrapperComponent],
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(HighlightjsWrapperComponent);
+  function setup() {
+    const fixture = TestBed.createComponent(HighlightjsWrapperComponent);
     fixture.componentRef.setInput('code', 'test code');
-    component = fixture.componentInstance;
+    const component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+    return { fixture, component };
+  }
 
   it('should create', () => {
+    const { component } = setup();
     expect(component).toBeTruthy();
   });
 });

--- a/libs/shared/base-editor-components/src/modal-confirm/modal-confirm.component.spec.ts
+++ b/libs/shared/base-editor-components/src/modal-confirm/modal-confirm.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 import { ModalConfirmComponent } from './modal-confirm.component';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
@@ -14,11 +14,6 @@ class ModalConfirmComponentPage extends PageObject<ModalConfirmComponent> {
 }
 
 describe('ModalConfirmComponent', () => {
-  let component: ModalConfirmComponent;
-  let fixture: ComponentFixture<ModalConfirmComponent>;
-  let hideSpy: Spy;
-  let page: ModalConfirmComponentPage;
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [ModalConfirmComponent, TranslateTestingModule],
@@ -26,16 +21,17 @@ describe('ModalConfirmComponent', () => {
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ModalConfirmComponent);
-    component = fixture.componentInstance;
+  function setup() {
+    const fixture = TestBed.createComponent(ModalConfirmComponent);
+    const component = fixture.componentInstance;
     fixture.detectChanges();
-    page = new ModalConfirmComponentPage(fixture);
-
-    hideSpy = spyOn(TestBed.inject(BsModalRef), 'hide');
-  });
+    const page = new ModalConfirmComponentPage(fixture);
+    const hideSpy = spyOn(TestBed.inject(BsModalRef), 'hide');
+    return { fixture, component, page, hideSpy };
+  }
 
   it('onConfirm() should correctly hide the modal', () => {
+    const { component, page, hideSpy } = setup();
     const nextSpy = spyOn(component.onClose, 'next');
 
     page.yesBtn.click();
@@ -46,6 +42,7 @@ describe('ModalConfirmComponent', () => {
   });
 
   it('onCancel() should correctly hide the modal', () => {
+    const { component, page, hideSpy } = setup();
     const nextSpy = spyOn(component.onClose, 'next');
 
     page.noBtn.click();

--- a/libs/shared/base-editor-components/src/query-output/query-error/query-error.component.spec.ts
+++ b/libs/shared/base-editor-components/src/query-output/query-error/query-error.component.spec.ts
@@ -1,23 +1,22 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { QueryErrorComponent } from './query-error.component';
 
 describe('QueryErrorComponent', () => {
-  let component: QueryErrorComponent;
-  let fixture: ComponentFixture<QueryErrorComponent>;
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [QueryErrorComponent],
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(QueryErrorComponent);
-    component = fixture.componentInstance;
+  function setup() {
+    const fixture = TestBed.createComponent(QueryErrorComponent);
+    const component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+    return { fixture, component };
+  }
 
   it('should create', () => {
+    const { component } = setup();
     expect(component).toBeTruthy();
   });
 });

--- a/libs/shared/selectors/src/selectors/faction-selector/faction-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/faction-selector/faction-selector-btn.component.spec.ts
@@ -1,25 +1,24 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 
 import { FactionSelectorBtnComponent } from './faction-selector-btn.component';
 import { ModalModule } from 'ngx-bootstrap/modal';
 
 describe('FactionSelectorBtnComponent', () => {
-  let component: FactionSelectorBtnComponent;
-  let fixture: ComponentFixture<FactionSelectorBtnComponent>;
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [ModalModule.forRoot(), FactionSelectorBtnComponent],
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(FactionSelectorBtnComponent);
-    component = fixture.componentInstance;
+  function setup() {
+    const fixture = TestBed.createComponent(FactionSelectorBtnComponent);
+    const component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+    return { fixture, component };
+  }
 
   it('should create', () => {
+    const { component } = setup();
     expect(component).toBeTruthy();
   });
 });

--- a/libs/shared/selectors/src/selectors/faction-selector/faction-selector-modal.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/faction-selector/faction-selector-modal.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 import { instance, mock } from 'ts-mockito';
 
@@ -8,10 +8,6 @@ import { FactionSearchService } from '../../search/faction-search.service';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 
 describe('FactionSelectorModalComponent', () => {
-  let component: FactionSelectorModalComponent;
-  let fixture: ComponentFixture<FactionSelectorModalComponent>;
-  let searchService: FactionSearchService;
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [FactionSelectorModalComponent, TranslateTestingModule],
@@ -23,16 +19,18 @@ describe('FactionSelectorModalComponent', () => {
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    searchService = TestBed.inject(FactionSearchService);
+  function setup() {
+    const searchService = TestBed.inject(FactionSearchService);
     searchService.query = '--mock query';
 
-    fixture = TestBed.createComponent(FactionSelectorModalComponent);
-    component = fixture.componentInstance;
+    const fixture = TestBed.createComponent(FactionSelectorModalComponent);
+    const component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+    return { searchService, fixture, component };
+  }
 
   it('should create', () => {
+    const { component } = setup();
     expect(component).toBeTruthy();
   });
 });

--- a/libs/shared/selectors/src/selectors/flags-selector/flags-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/flags-selector/flags-selector-btn.component.spec.ts
@@ -1,25 +1,23 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { FlagsSelectorBtnComponent } from './flags-selector-btn.component';
 import { ModalModule } from 'ngx-bootstrap/modal';
 
 describe('FlagsSelectorBtnComponent', () => {
-  let component: FlagsSelectorBtnComponent;
-  let fixture: ComponentFixture<FlagsSelectorBtnComponent>;
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [ModalModule.forRoot(), FlagsSelectorBtnComponent],
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(FlagsSelectorBtnComponent);
-    component = fixture.componentInstance;
+  function setup() {
+    const fixture = TestBed.createComponent(FlagsSelectorBtnComponent);
+    const component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+    return { fixture, component };
+  }
 
   it('should create', () => {
+    const { component } = setup();
     expect(component).toBeTruthy();
   });
 });

--- a/libs/shared/selectors/src/selectors/flags-selector/flags-selector-modal.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/flags-selector/flags-selector-modal.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
 import { FlagsSelectorModalComponent } from './flags-selector-modal.component';
@@ -7,10 +7,6 @@ import { Flag } from '@keira/shared/constants';
 import { TranslateTestingModule } from '@keira/shared/test-utils';
 
 describe('FlagsSelectorModalComponent', () => {
-  let component: FlagsSelectorModalComponent;
-  let fixture: ComponentFixture<FlagsSelectorModalComponent>;
-  let flagsService: FlagsService;
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [FlagsSelectorModalComponent, TranslateTestingModule],
@@ -18,19 +14,21 @@ describe('FlagsSelectorModalComponent', () => {
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    flagsService = TestBed.inject(FlagsService);
-
-    fixture = TestBed.createComponent(FlagsSelectorModalComponent);
-    component = fixture.componentInstance;
+  function setup() {
+    const flagsService = TestBed.inject(FlagsService);
+    const fixture = TestBed.createComponent(FlagsSelectorModalComponent);
+    const component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+    return { flagsService, fixture, component };
+  }
 
   it('should safely create without config', () => {
+    const { component } = setup();
     expect(component).toBeTruthy();
   });
 
   it('should properly handle config (if any)', () => {
+    const { component, flagsService } = setup();
     const bits = [false, true, false];
     const flags: Flag[] = [{ bit: 1, name: 'my-flag' }];
     const value = 123;
@@ -46,6 +44,7 @@ describe('FlagsSelectorModalComponent', () => {
   });
 
   it('toogleBit() should properly work', () => {
+    const { component, flagsService } = setup();
     const value = 123456;
     const spyGetValueFromBits = spyOn(flagsService, 'getValueFromBits').and.returnValue(value);
     component.flagValues = [true, false, true];
@@ -59,27 +58,24 @@ describe('FlagsSelectorModalComponent', () => {
   });
 
   it('toggleBit() override should properly work', () => {
+    const { component, flagsService } = setup();
     const value = 123456;
     const overrideDefaultBehavior = true;
     const flags = [{ bit: 1, name: 'flag-1' }];
     const initialFlagValues = [true, false, true];
     const updatedValue = 654321;
 
-    // Set up the component's initial state
     component.value = value;
     component.config = { name: 'Mock Modal Name', flags, overrideDefaultBehavior };
     component.flagValues = [...initialFlagValues];
 
-    // Spy on the flagsService.getValueFromBits method
     const spyGetValueFromBits = spyOn(flagsService, 'getValueFromBits').and.returnValue(updatedValue);
 
-    // Act: Call toggleBit with a specific bit index
-    component.toggleBit(1); // Toggle the second bit (index 1)
+    component.toggleBit(1);
 
-    // Assertions
-    expect(component.flagValues).toEqual([true, true, true]); // Bit at index 1 should toggle to `true`
+    expect(component.flagValues).toEqual([true, true, true]);
     expect(spyGetValueFromBits).toHaveBeenCalledTimes(1);
     expect(spyGetValueFromBits).toHaveBeenCalledWith([true, true, true], overrideDefaultBehavior);
-    expect(component.value).toEqual(updatedValue); // Value should update based on the override behavior
+    expect(component.value).toEqual(updatedValue);
   });
 });

--- a/libs/shared/selectors/src/selectors/language-selector/language-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/language-selector/language-selector-btn.component.spec.ts
@@ -1,24 +1,23 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { LanguageSelectorBtnComponent } from './language-selector-btn.component';
 
 describe('LanguageSelectorBtnComponent', () => {
-  let component: LanguageSelectorBtnComponent;
-  let fixture: ComponentFixture<LanguageSelectorBtnComponent>;
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [ModalModule.forRoot(), LanguageSelectorBtnComponent],
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(LanguageSelectorBtnComponent);
-    component = fixture.componentInstance;
+  function setup() {
+    const fixture = TestBed.createComponent(LanguageSelectorBtnComponent);
+    const component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+    return { fixture, component };
+  }
 
   it('should create', () => {
+    const { component } = setup();
     expect(component).toBeTruthy();
   });
 });

--- a/libs/shared/selectors/src/selectors/language-selector/language-selector-modal.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/language-selector/language-selector-modal.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { TranslateTestingModule } from '@keira/shared/test-utils';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 import { instance, mock } from 'ts-mockito';
@@ -7,10 +7,6 @@ import { LanguageSelectorModalComponent } from './language-selector-modal.compon
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 
 describe('LanguageSelectorModalComponent', () => {
-  let component: LanguageSelectorModalComponent;
-  let fixture: ComponentFixture<LanguageSelectorModalComponent>;
-  let searchService: LanguageSearchService;
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [LanguageSelectorModalComponent, TranslateTestingModule],
@@ -22,16 +18,18 @@ describe('LanguageSelectorModalComponent', () => {
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    searchService = TestBed.inject(LanguageSearchService);
+  function setup() {
+    const searchService = TestBed.inject(LanguageSearchService);
     searchService.query = '--mock query';
 
-    fixture = TestBed.createComponent(LanguageSelectorModalComponent);
-    component = fixture.componentInstance;
+    const fixture = TestBed.createComponent(LanguageSelectorModalComponent);
+    const component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+    return { searchService, fixture, component };
+  }
 
   it('should create', () => {
+    const { component } = setup();
     expect(component).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- refactor various selector and editor component specs to use local setup helpers
- refactor create component and gameobject template addon integration specs
- remove shared variables from tests

## Testing
- `npx nx run-many --target=test --all --skip-nx-cache` *(fails: requires nx installation)*

------
https://chatgpt.com/codex/tasks/task_e_685860cc094c8325b65de0ec634bf073