### PR TITLE
fix(features/gameobject): display correct type name

### DIFF
--- a/libs/features/gameobject/src/select-gameobject/select-gameobject.component.html
+++ b/libs/features/gameobject/src/select-gameobject/select-gameobject.component.html
@@ -69,7 +69,7 @@
           <ngx-datatable-column name="Name" prop="name" [minWidth]="120" [maxWidth]="600"></ngx-datatable-column>
           <ngx-datatable-column name="Type" prop="type" [minWidth]="75" [maxWidth]="100">
             <ng-template let-row="row" ngx-datatable-cell-template>
-              {{ GAMEOBJECT_TYPE[row.type].name }}
+              {{ GAMEOBJECT_TYPE[row.type + 1].name }}
             </ng-template>
           </ngx-datatable-column>
           <ngx-datatable-column name="Display Id" prop="displayId" [minWidth]="75" [maxWidth]="100"></ngx-datatable-column>


### PR DESCRIPTION
### Changes
GameObject type Select displays the correct enum name


culprit: 
- https://github.com/azerothcore/Keira3/blob/1c7537f14029474f6bdc1ee28c13f59dcc4ea124/libs/features/gameobject/src/select-gameobject/select-gameobject.component.ts#L40


### How to test
1. gameobject tab, select
2. search for door
3. See that type name is off by 1

![keira_0_should_be_door](https://github.com/user-attachments/assets/92dd3331-f90a-419d-9374-12926fad341e)
