### PR TITLE
Only run the query when data changes

### DIFF
--- a/libs/shared/sai-editor/src/sai-editor.component.html
+++ b/libs/shared/sai-editor/src/sai-editor.component.html
@@ -1,4 +1,4 @@
-<keira-sai-top-bar [isNew]="getHandler().isNew" [selected]="getHandler().selected" [selectedName]="getHandler().getName() | async" />
+<keira-sai-top-bar [isNew]="getHandler().isNew" [selected]="getHandler().selected" [selectedName]="selectedName$ | async" />
 
 <div class="container-fluid">
   @if (editorService.loading) {

--- a/libs/shared/sai-editor/src/sai-editor.component.ts
+++ b/libs/shared/sai-editor/src/sai-editor.component.ts
@@ -67,6 +67,8 @@ import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
 import { EditorButtonsComponent, QueryOutputComponent } from '@keira/shared/base-editor-components';
 import { AsyncPipe } from '@angular/common';
+import { Observable } from 'rxjs';
+import { shareReplay } from 'rxjs/operators';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -90,6 +92,13 @@ import { AsyncPipe } from '@angular/common';
 export class SaiEditorComponent extends MultiRowEditorComponent<SmartScripts> implements OnInit {
   public override readonly editorService = inject(SaiEditorService);
   protected override readonly handlerService = inject(SaiHandlerService);
+
+  selectedName$!: Observable<string>;
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+    this.selectedName$ = this.handlerService.getName().pipe(shareReplay(1));
+  }
 
   readonly EVENT_PHASE_MASK = EVENT_PHASE_MASK;
   readonly SMART_EVENT_FLAGS = SMART_EVENT_FLAGS;


### PR DESCRIPTION
Closes: https://github.com/azerothcore/Keira3/issues/3500

Prior to this you would run TOO MANY queries (at the end of this PR) in milliseconds


- For `libs\shared\sai-editor\src\sai-editor.component.html` 

Now uses `selectedName$` instead of `getHandler().getName()`


- `libs\shared\sai-editor\src\sai-editor.component.ts`

Now "caches" the value being looked/searched and only updates / run the query if any changes happen instead of checking multiple times a milisecond.
`SELECT ct.name FROM creature_template AS ct INNER JOIN creature AS c ON c.id1 = ct.entry WHERE c.guid = $ID`

https://gist.github.com/TheSCREWEDSoftware/52981434a8615ae770e638125071df97