### PR TITLE
fix: SheatheType selection in Item Template

### DIFF
--- a/libs/shared/acore-world-model/src/options/item-sheath.ts
+++ b/libs/shared/acore-world-model/src/options/item-sheath.ts
@@ -6,5 +6,5 @@ export const ITEM_SHEAT: Option[] = [
   { value: 3, name: `One Handed - On the left-hand side of the character's waist.` },
   { value: 4, name: `Shield - On the middle of the character's back.` },
   { value: 5, name: `Enchanter's Rod` },
-  { value: 6, name: `Off hand - On the right-hand side of the character's waist.` },
+  { value: 7, name: `Off hand - On the right-hand side of the character's waist.` },
 ];


### PR DESCRIPTION
Hi,

currently the listed types of `sheath` are listed as:
```
1 Two Handed Weapon - Diagonally across the back pointing downwards.
2 Staff - diagonally across the back pointing upwards.
3 One Handed - On the left-hand side of the character's waist.
4 Shield - On the middle of the character's back.
5 Enchanter's Rod
6 Off hand - On the right-hand side of the character's waist.
```

which is incorrect, the correct SheatheTypes are:
```
1 Two Handed Weapon | Diagonally across the back pointing downwards.
2 Staff | Diagonally across the back pointing upwards.
3 One Handed | On the left-hand side of the character's waist.
4 Shield | On the middle of the character's back.
5 Tool | ? usually not equippable ?
7 Off hand | On the right-hand side of the character's waist.
```
[scource](https://trinitycore.info/files/DBC/335/item)

as an example you check item entry `7610` where it is an off-hand item and correctly set to `7`. you can also check the `item.dbc` about this item:
```
| ID   | ClassID | SubclassID | Sound_Override_Subclassid  | Material | DisplayInfoID  | InventoryType  | SheatheType |
|------|---------|------------|----------------------------|----------|----------------|----------------|-------------|
| 7610 | 4       | 0          | -1                         | -1       | 21596          | 23             | 7           |

```

I assume that information was taken from [azerothcore.org/wiki/item_template#sheath](https://www.azerothcore.org/wiki/item_template#sheath) which is also wrong.


<img width="2271" height="1072" alt="Image" src="https://github.com/user-attachments/assets/0516e8a6-5957-402a-a955-38c152815be9" />