### PR TITLE
feat: add modals selector for Smart AI CastFlags & TriggerFlags

### DIFF
--- a/libs/shared/acore-world-model/src/flags/smart-action-cast-flags.ts
+++ b/libs/shared/acore-world-model/src/flags/smart-action-cast-flags.ts
@@ -1,0 +1,15 @@
+import { Flag } from '@keira/shared/constants';
+
+export const SMART_ACTION_CAST_FLAGS: Flag[] = [
+  { bit: 0, name: 'SMARTCAST_INTERRUPT_PREVIOUS - Interrupt any spell casting' },
+  { bit: 1, name: 'SMARTCAST_TRIGGERED - Triggered (this makes spell cost zero mana and have no cast time)' },
+  { bit: 2, name: 'SMARTCAST_AURA_NOT_PRESENT - Only casts the spell if the target does not have an aura from the spell' },
+  { bit: 3, name: 'SMARTCAST_COMBAT_MOVE - Prevent combat movement on cast, allow on fail range, mana, LOS' },
+  { bit: 4, name: "SMARTCAST_THREATLIST_NOT_SINGLE - Only cast if the source's threatlist is higher than one. This includes pets" },
+  { bit: 5, name: 'SMARTCAST_TARGET_POWER_MANA - Only cast if the target has power type mana' },
+  {
+    bit: 6,
+    name: 'SMARTCAST_ENABLE_COMBAT_MOVE_ON_LOS - Enable combat chase movement when the spell fails due to line-of-sight. Use with SMARTCAST_COMBAT_MOVE.',
+  },
+  { bit: 7, name: 'SMARTCAST_MAIN_SPELL - Use with SMARTCAST_COMBAT_MOVE to set attack distance based on spell range' },
+];

--- a/libs/shared/acore-world-model/src/flags/smart-action-cast-triggered-flags.ts
+++ b/libs/shared/acore-world-model/src/flags/smart-action-cast-triggered-flags.ts
@@ -5,7 +5,7 @@ export const SMART_ACTION_CAST_TRIGGERED_FLAGS: Flag[] = [
   { bit: 1, name: 'TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD - Will ignore Spell and Category cooldowns' },
   { bit: 2, name: 'TRIGGERED_IGNORE_POWER_AND_REAGENT_COST - Will ignore power and reagent cost' },
   { bit: 3, name: 'TRIGGERED_IGNORE_CAST_ITEM - Will not take away cast item or update related achievement criteria' },
-  { bit: 4, name: 'RIGGERED_IGNORE_AURA_SCALING - Will ignore aura scaling' },
+  { bit: 4, name: 'TRIGGERED_IGNORE_AURA_SCALING - Will ignore aura scaling' },
   { bit: 5, name: 'TRIGGERED_IGNORE_CAST_IN_PROGRESS - Will not check if a current cast is in progress' },
   { bit: 6, name: 'TRIGGERED_IGNORE_COMBO_POINTS - Will ignore combo point requirement' },
   { bit: 7, name: 'TRIGGERED_CAST_DIRECTLY - In Spell::prepare, will be cast directly without setting containers for executed spell' },

--- a/libs/shared/acore-world-model/src/flags/smart-action-cast-triggered-flags.ts
+++ b/libs/shared/acore-world-model/src/flags/smart-action-cast-triggered-flags.ts
@@ -1,0 +1,25 @@
+import { Flag } from '@keira/shared/constants';
+
+export const SMART_ACTION_CAST_TRIGGERED_FLAGS: Flag[] = [
+  { bit: 0, name: 'TRIGGERED_IGNORE_GCD - Will ignore GCD' },
+  { bit: 1, name: 'TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD - Will ignore Spell and Category cooldowns' },
+  { bit: 2, name: 'TRIGGERED_IGNORE_POWER_AND_REAGENT_COST - Will ignore power and reagent cost' },
+  { bit: 3, name: 'TRIGGERED_IGNORE_CAST_ITEM - Will not take away cast item or update related achievement criteria' },
+  { bit: 4, name: 'RIGGERED_IGNORE_AURA_SCALING - Will ignore aura scaling' },
+  { bit: 5, name: 'TRIGGERED_IGNORE_CAST_IN_PROGRESS - Will not check if a current cast is in progress' },
+  { bit: 6, name: 'TRIGGERED_IGNORE_COMBO_POINTS - Will ignore combo point requirement' },
+  { bit: 7, name: 'TRIGGERED_CAST_DIRECTLY - In Spell::prepare, will be cast directly without setting containers for executed spell' },
+  { bit: 8, name: "TRIGGERED_IGNORE_AURA_INTERRUPT_FLAGS - Will ignore interruptible aura's at cast" },
+  { bit: 9, name: 'TRIGGERED_IGNORE_SET_FACING - Will not adjust facing to target (if any)' },
+  { bit: 10, name: 'TRIGGERED_IGNORE_SHAPESHIFT - Will ignore shapeshift checks' },
+  { bit: 11, name: 'TRIGGERED_IGNORE_CASTER_AURASTATE - Will ignore caster aura states including combat requirements and death state' },
+  { bit: 12, name: 'TRIGGERED_IGNORE_CASTER_MOUNTED_OR_ON_VEHICLE - Will ignore mounted/on vehicle restrictions' },
+  { bit: 13, name: 'TRIGGERED_IGNORE_CASTER_AURAS - Will ignore caster aura restrictions or requirements' },
+  { bit: 14, name: 'TRIGGERED_DISALLOW_PROC_EVENTS - Disallows proc events from triggered spell (default)' },
+  { bit: 15, name: 'TRIGGERED_DONT_REPORT_CAST_ERROR - Will return SPELL_FAILED_DONT_REPORT in CheckCast functions' },
+  { bit: 16, name: 'TRIGGERED_FULL_MASK - All triggered flags' },
+  { bit: 17, name: 'TRIGGERED_IGNORE_EQUIPPED_ITEM_REQUIREMENT - Will ignore equipped item requirements' },
+  { bit: 18, name: 'TRIGGERED_NO_PERIODIC_RESET - Periodic aura tick wont be reset on override' },
+  { bit: 19, name: 'TRIGGERED_IGNORE_EFFECTS - Ignore spell effects - used for ritual portals' },
+  { bit: 20, name: 'TRIGGERED_FULL_DEBUG_MASK' },
+];

--- a/libs/shared/acore-world-model/src/index.ts
+++ b/libs/shared/acore-world-model/src/index.ts
@@ -95,6 +95,8 @@ export * from './flags/spell-dbc-item-flags';
 export * from './flags/spell-school-mask';
 export * from './flags/unit-flags';
 export * from './flags/unit-flags2';
+export * from './flags/smart-action-cast-flags';
+export * from './flags/smart-action-cast-triggered-flags';
 
 export * from './options/conditions';
 export * from './options/creature-addon-bytes1';

--- a/libs/shared/sai-editor/src/constants/sai-actions.ts
+++ b/libs/shared/sai-editor/src/constants/sai-actions.ts
@@ -274,11 +274,8 @@ SAI_ACTION_PARAM1_NAMES[SAI_ACTIONS.CAST] = 'SpellId';
 SAI_ACTION_PARAM2_NAMES[SAI_ACTIONS.CAST] = 'CastFlags';
 SAI_ACTION_PARAM3_NAMES[SAI_ACTIONS.CAST] = 'TriggerFlags';
 SAI_ACTION_PARAM4_NAMES[SAI_ACTIONS.CAST] = 'LimitTargets';
-SAI_ACTION_PARAM2_TOOLTIPS[SAI_ACTIONS.CAST] = `1 - Interrupt any spell casting;
-2 - Triggered (this makes spell cost zero mana and have no cast time);
-32 - Only casts the spell if the target does not have an aura from the spell;
-64 - Prevent combat movement on cast, allow on fail range, mana, LOS;
-128 - Only cast if the source's threatlist is higher than one. This includes pets`;
+SAI_ACTION_PARAM2_TOOLTIPS[SAI_ACTIONS.CAST] = 'Cannot be 0';
+SAI_ACTION_PARAM3_TOOLTIPS[SAI_ACTIONS.CAST] = '0 = Not triggered';
 SAI_ACTION_PARAM4_TOOLTIPS[SAI_ACTIONS.CAST] = '0 = all targets';
 
 // SMART_ACTION_SUMMON_CREATURE

--- a/libs/shared/sai-editor/src/sai-editor.component.html
+++ b/libs/shared/sai-editor/src/sai-editor.component.html
@@ -272,6 +272,14 @@
               <div class="form-group col-7">
                 <label class="control-label" id="label-action-param2">
                   {{ getName('param2', ACTION_PARAM2_NAMES[selectedAction]) }}
+                  @if (selectedAction === SAI_ACTIONS.CAST) {
+                    <keira-flags-selector-btn
+                      [control]="editorService.form.controls.action_param2"
+                      [disabled]="editorService.form.controls.action_param2.disabled"
+                      [config]="{ flags: SMART_ACTION_CAST_FLAGS, name: 'action_param2' }"
+                      [modalClass]="'modal-lg'"
+                    />
+                  }
                   <i
                     class="fas fa-info-circle ms-1"
                     placement="auto"
@@ -288,6 +296,14 @@
               <div class="form-group col-7">
                 <label class="control-label" id="label-action-param3">
                   {{ getName('param3', ACTION_PARAM3_NAMES[selectedAction]) }}
+                  @if (selectedAction === SAI_ACTIONS.CAST) {
+                    <keira-flags-selector-btn
+                      [control]="editorService.form.controls.action_param3"
+                      [disabled]="editorService.form.controls.action_param3.disabled"
+                      [config]="{ flags: SMART_ACTION_CAST_TRIGGERED_FLAGS, name: 'action_param3' }"
+                      [modalClass]="'modal-lg'"
+                    />
+                  }
                   <i
                     class="fas fa-info-circle ms-1"
                     placement="auto"

--- a/libs/shared/sai-editor/src/sai-editor.component.integration.spec.ts
+++ b/libs/shared/sai-editor/src/sai-editor.component.integration.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { SAI_TYPES, SmartScripts } from '@keira/shared/acore-world-model';
+import { SAI_TYPES, SMART_ACTION_CAST_TRIGGERED_FLAGS, SmartScripts } from '@keira/shared/acore-world-model';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
@@ -665,6 +665,48 @@ describe('SaiEditorComponent integration tests', () => {
       expect(page.action4Name.innerText).toContain('EmoteId4');
       expect(page.action5Name.innerText).toContain('EmoteId5');
       expect(page.action6Name.innerText).toContain('EmoteId6');
+    });
+
+    it('should show flags selectors for SMART_ACTION_CAST', () => {
+      const { page } = setup(true);
+      page.addNewRow();
+
+      expect(page.getSelectorBtn('action_param2', false)).toBeFalsy();
+      expect(page.getSelectorBtn('action_param3', false)).toBeFalsy();
+
+      page.setSelectValueById('action_type', SAI_ACTIONS.CAST);
+
+      expect(page.action2Name.innerText).toContain('CastFlags');
+      expect(page.getSelectorBtn('action_param2')).toBeTruthy();
+      expect(page.action3Name.innerText).toContain('TriggerFlags');
+      expect(page.getSelectorBtn('action_param3')).toBeTruthy();
+
+      page.setSelectValueById('action_type', SAI_ACTIONS.TALK);
+
+      expect(page.getSelectorBtn('action_param2', false)).toBeFalsy();
+      expect(page.getSelectorBtn('action_param3', false)).toBeFalsy();
+    });
+
+    it('should use SMART_ACTION_CAST_TRIGGERED_FLAGS for SMART_ACTION_CAST TriggerFlags selector', async () => {
+      const { page } = setup(true);
+      page.addNewRow();
+      page.setSelectValueById('action_type', SAI_ACTIONS.CAST);
+
+      page.clickElement(page.getSelectorBtn('action_param3'));
+      await page.whenReady();
+      page.expectModalDisplayed();
+
+      const flagRows = Array.from(document.querySelectorAll<HTMLTableRowElement>('#flags-table tbody tr'));
+      expect(flagRows.length).toBe(SMART_ACTION_CAST_TRIGGERED_FLAGS.length);
+      expect(flagRows[0].innerText).toContain(SMART_ACTION_CAST_TRIGGERED_FLAGS[0].name);
+      expect(flagRows[3].innerText).toContain(SMART_ACTION_CAST_TRIGGERED_FLAGS[3].name);
+
+      page.toggleFlagInRowExternal(3); // +2^3
+      await page.whenReady();
+      page.clickModalSelect();
+      await page.whenReady();
+
+      expect(page.getInputById('action_param3').value).toEqual('8');
     });
 
     it('target param names should correctly work', () => {

--- a/libs/shared/sai-editor/src/sai-editor.component.ts
+++ b/libs/shared/sai-editor/src/sai-editor.component.ts
@@ -1,5 +1,12 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
-import { EVENT_PHASE_MASK, SAI_TYPES, SMART_EVENT_FLAGS, SmartScripts } from '@keira/shared/acore-world-model';
+import {
+  EVENT_PHASE_MASK,
+  SAI_TYPES,
+  SMART_ACTION_CAST_FLAGS,
+  SMART_ACTION_CAST_TRIGGERED_FLAGS,
+  SMART_EVENT_FLAGS,
+  SmartScripts,
+} from '@keira/shared/acore-world-model';
 import {
   SAI_ACTION_PARAM1_NAMES,
   SAI_ACTION_PARAM1_TOOLTIPS,

--- a/libs/shared/sai-editor/src/sai-editor.component.ts
+++ b/libs/shared/sai-editor/src/sai-editor.component.ts
@@ -93,6 +93,8 @@ export class SaiEditorComponent extends MultiRowEditorComponent<SmartScripts> im
 
   readonly EVENT_PHASE_MASK = EVENT_PHASE_MASK;
   readonly SMART_EVENT_FLAGS = SMART_EVENT_FLAGS;
+  readonly SMART_ACTION_CAST_FLAGS = SMART_ACTION_CAST_FLAGS;
+  readonly SMART_ACTION_CAST_TRIGGERED_FLAGS = SMART_ACTION_CAST_TRIGGERED_FLAGS;
   readonly SAI_EVENTS = SAI_EVENTS;
   readonly SAI_EVENTS_KEYS = SAI_EVENTS_KEYS;
   readonly SAI_ACTIONS = SAI_ACTIONS;


### PR DESCRIPTION
Adding modals for SMART_ACTION_CAST_FLAGS & SMART_ACTION_CAST_TRIGGERED_FLAGS used in SmartAI.
- Added definitons for CastFlags and TriggeredFlags
- Adjusted tooltips

Not happy with the testpart though.

<img width="826" height="391" alt="grafik" src="https://github.com/user-attachments/assets/6e1f5cba-cbaa-4f06-87ed-84fb85430a36" />
---
<img width="780" height="598" alt="grafik" src="https://github.com/user-attachments/assets/37b1fa38-358a-4ef9-9bde-b0a50e64d595" />
---
<img width="775" height="979" alt="grafik" src="https://github.com/user-attachments/assets/9a9c6b5a-979e-45ae-9854-6123f64edcce" />