### PR TITLE
chore: remove unneeded electron-builder flags

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -5,15 +5,9 @@
     "output": "release/"
   },
   "files": ["dist/browser/**/*", "main.js", "main.js.map"],
-  "electronFuses": {
-    "enableEmbeddedAsarIntegrityValidation": false,
-    "onlyLoadAppFromAsar": false
-  },
   "win": {
     "icon": "dist/browser",
-    "target": ["portable"],
-    "signAndEditExecutable": false,
-    "verifyUpdateCodeSignature": false
+    "target": ["portable"]
   },
   "mac": {
     "icon": "dist/browser",


### PR DESCRIPTION
Drop the electronFuses block, win.verifyUpdateCodeSignature, and win.signAndEditExecutable added in #3740. None of them are required for the ssh2 tunnel to work:

- ssh2's native bindings (sshcrypto.node, cpufeatures.node) are auto-unpacked by Electron and don't conflict with default fuses.
- onlyLoadAppFromAsar only governs the entry point (main.js), which stays inside the asar.
- Embedded asar integrity validation is handled correctly by modern electron-builder, including for asarUnpack entries.
- verifyUpdateCodeSignature only matters when electron-updater is active; Keira3 doesn't ship the auto-updater.
- signAndEditExecutable: false skipped not only signing (which electron-builder skips automatically without a cert) but also rcedit, which means the portable .exe shipped without its icon or version metadata. Letting it run by default restores both.