### PR TITLE
fix(item): rename TotemCategory label to Tools Category (#3783)

### DIFF
--- a/libs/features/item/src/item-template/item-template.component.html
+++ b/libs/features/item/src/item-template/item-template.component.html
@@ -189,11 +189,11 @@
               <input [formControlName]="'ContainerSlots'" id="ContainerSlots" type="number" class="form-control form-control-sm" />
             </div>
             <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
-              <label class="control-label" for="TotemCategory">TotemCategory</label>
+              <label class="control-label" for="TotemCategory">Tools Category</label>
               <keira-single-value-selector-btn
                 [control]="editorService.form.controls.TotemCategory"
                 [disabled]="editorService.form.controls.TotemCategory.disabled"
-                [config]="{ options: TOTEM_CATEGORY, name: 'TotemCategory' }"
+                [config]="{ options: TOTEM_CATEGORY, name: 'Tools Category' }"
                 [modalClass]="'modal-md'"
               />
               <input [formControlName]="'TotemCategory'" id="TotemCategory" type="number" class="form-control form-control-sm" />


### PR DESCRIPTION
Closes #3783

Renames the item editor's user-facing "TotemCategory" label and the value-picker modal title to "Tools Category", matching WowHead/AoWoW terminology. The DB column and form control id remain `TotemCategory`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the category field label in the item form from "TotemCategory" to "Tools Category" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->