### PR TITLE
ci: auto-merge non-major dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      dev-dependencies:
+        dependency-type: development

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,20 @@
+name: dependabot-auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+      - name: Enable auto-merge
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds Dependabot configuration and a workflow that auto-merges Dependabot PRs once required CI passes.

- `.github/dependabot.yml`: weekly npm updates, dev dependencies grouped into a single PR.
- `.github/workflows/dependabot-auto-merge.yml`: enables GitHub auto-merge (squash) on Dependabot PRs, skipping `semver-major` bumps so breaking updates still need manual review.

Auto-merge only completes after the required status checks pass, so two repo settings are still needed for this to take effect:
1. Settings -> General -> enable "Allow auto-merge".
2. A branch protection rule on `master` marking the `main` workflow jobs as required checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated weekly dependency update checks for npm packages to keep the project current.
  * Enabled automatic merging of dependency updates, excluding major version changes, to streamline the maintenance workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->