### PR TITLE
fix(gameobject): hide info icon for empty data field tooltips

### DIFF
--- a/libs/features/gameobject/src/gameobject-template/gameobject-template.component.html
+++ b/libs/features/gameobject/src/gameobject-template/gameobject-template.component.html
@@ -78,10 +78,11 @@
           </span>
           <div class="row">
             @for (item of [].constructor(24); track item; let i = $index) {
+              @let fieldDefinition = dataFieldDefinition(i);
               <div class="form-group col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2">
-                <label class="control-label" for="Data{{ i }}">{{ dataFieldDefinition(i).name }}</label>
-                @if (!!dataFieldDefinition(i).tooltip) {
-                  <i class="fas fa-info-circle ms-1" placement="auto" [tooltip]="dataFieldDefinition(i).tooltip | translate"></i>
+                <label class="control-label" for="Data{{ i }}">{{ fieldDefinition.name }}</label>
+                @if (fieldDefinition.tooltip && fieldDefinition.tooltip !== 'EMPTY') {
+                  <i class="fas fa-info-circle ms-1" placement="auto" [tooltip]="fieldDefinition.tooltip | translate"></i>
                 }
                 <input [formControlName]="'Data' + i" id="Data{{ i }}" type="number" class="form-control form-control-sm" />
               </div>

--- a/libs/features/gameobject/src/gameobject-template/gameobject-template.integration.spec.ts
+++ b/libs/features/gameobject/src/gameobject-template/gameobject-template.integration.spec.ts
@@ -173,6 +173,16 @@ describe('GameobjectTemplate integration tests', () => {
       page.expectFullQueryToContain('35');
     });
 
+    it('should only render the info tooltip icon for data fields with a non-empty tooltip', () => {
+      const { fixture } = setup(false);
+      const getDataFieldIcon = (index: number) =>
+        fixture.nativeElement.querySelector(`#Data${index}`).closest('.form-group').querySelector('i.fa-info-circle');
+
+      // type 0: Data0 (startOpen) has a real tooltip, Data4 (openTextID) maps to the empty 'EMPTY' tooltip
+      expect(getDataFieldIcon(0)).toBeTruthy();
+      expect(getDataFieldIcon(4)).toBeFalsy();
+    });
+
     it.skip('changing a value via SingleValueSelector should correctly work', async () => {
       const { page } = setup(false);
       const field = 'type';


### PR DESCRIPTION
Closes #3830

## Problem

In the Gameobject Template editor, several data field hints (e.g. `openTextID`, `floatingTooltip`, `conditionid1`, `xplevel`, `xpDifficulty`, `lootlevel`, `Group`) showed the info-circle icon but displayed no tooltip on hover.

These fields are defined with `tooltip: 'EMPTY'`, and the `EMPTY` translation key maps to an empty string. The template rendered the icon whenever the tooltip value was truthy, and the string `'EMPTY'` is always truthy, so the icon appeared with empty hover content.

## Fix

Only render the info-circle icon when the field has a meaningful, non-empty tooltip (not falsy and not the `'EMPTY'` placeholder).

## Testing

Added an integration test asserting the icon renders for a field with a real tooltip and is omitted for an `EMPTY`-mapped field. Existing gameobject-template tests and lint pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed tooltip icons in the gameobject template editor to display only for data fields with actual tooltip content.

* **Tests**
  * Added integration tests to verify tooltip icon rendering behavior for data fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->