### PR TITLE
chore: add sai event damaged

### DIFF
--- a/libs/shared/sai-editor/src/constants/sai-event.ts
+++ b/libs/shared/sai-editor/src/constants/sai-event.ts
@@ -366,8 +366,11 @@ SAI_EVENT_PARAM1_NAMES[SAI_EVENTS.DAMAGED] = 'MinDamage';
 SAI_EVENT_PARAM2_NAMES[SAI_EVENTS.DAMAGED] = 'MaxDamage';
 SAI_EVENT_PARAM3_NAMES[SAI_EVENTS.DAMAGED] = 'RepeatMin';
 SAI_EVENT_PARAM4_NAMES[SAI_EVENTS.DAMAGED] = 'RepeatMax';
+SAI_EVENT_PARAM5_NAMES[SAI_EVENTS.DAMAGED] = 'HpPct';
 SAI_EVENT_PARAM1_TOOLTIPS[SAI_EVENTS.DAMAGED] = 'Minimum amount of damage required to trigger this event';
 SAI_EVENT_PARAM2_TOOLTIPS[SAI_EVENTS.DAMAGED] = 'Maximum allowed damage to make this event be able to trigger';
+SAI_EVENT_PARAM5_TOOLTIPS[SAI_EVENTS.DAMAGED] =
+  'Health percentage (1-100). When set, the event switches to health check mode: it fires once when incoming damage drops health below this threshold (MinDamage/MaxDamage/Repeat are ignored). Leave 0 for the normal damage-amount mode.';
 
 // SMART_EVENT_DAMAGED_TARGET
 SAI_EVENT_TOOLTIPS[SAI_EVENTS.DAMAGED_TARGET] = 'On target damaged for a certain amount';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health-percentage mode for the damage event, allowing it to trigger based on a target’s HP percentage instead of damage amount.
  * Updated the event guidance text to explain how the new mode behaves and when it overrides the usual damage settings.

* **Documentation**
  * Refreshed the inline help text for the event’s inputs to better describe the available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->