### PR TITLE
feat(sai): add SMART_TARGET_SHARED_OWNER_ENTITIES

### DIFF
--- a/libs/shared/sai-editor/src/constants/sai-targets.ts
+++ b/libs/shared/sai-editor/src/constants/sai-targets.ts
@@ -37,6 +37,7 @@ export enum SAI_TARGETS {
   SUMMONED_CREATURES = 204,
   INSTANCE_STORAGE = 205,
   FORMATION = 206,
+  SHARED_OWNER_ENTITIES = 207,
 }
 
 export const SAI_TARGETS_KEYS = getEnumKeys(SAI_TARGETS);
@@ -315,10 +316,22 @@ SAI_TARGET_PARAM2_NAMES[SAI_TARGETS.INSTANCE_STORAGE] = 'Type';
 SAI_TARGET_PARAM2_TOOLTIPS[SAI_TARGETS.INSTANCE_STORAGE] = 'creature (1), gameobject (2)';
 
 // SMART_TARGET_FORMATION
-SAI_TARGET_TOOLTIPS[SAI_TARGETS.FORMATION] = 'Targets members of the creature\'s formation group (creature_formations table). Dead members are excluded.';
+SAI_TARGET_TOOLTIPS[SAI_TARGETS.FORMATION] =
+  "Targets members of the creature's formation group (creature_formations table). Dead members are excluded.";
 SAI_TARGET_PARAM1_NAMES[SAI_TARGETS.FORMATION] = 'Type';
 SAI_TARGET_PARAM2_NAMES[SAI_TARGETS.FORMATION] = 'CreatureEntry';
 SAI_TARGET_PARAM3_NAMES[SAI_TARGETS.FORMATION] = 'ExcludeSelf';
 SAI_TARGET_PARAM1_TOOLTIPS[SAI_TARGETS.FORMATION] = '0: members only, 1: leader only, 2: all';
 SAI_TARGET_PARAM2_TOOLTIPS[SAI_TARGETS.FORMATION] = '0: any entry';
 SAI_TARGET_PARAM3_TOOLTIPS[SAI_TARGETS.FORMATION] = '(0/1) exclude this creature';
+
+// SMART_TARGET_SHARED_OWNER_ENTITIES
+SAI_TARGET_TOOLTIPS[SAI_TARGETS.SHARED_OWNER_ENTITIES] =
+  'Targets the creatures or gameobjects sharing the same owner, charmer or summoner as the object running the script. ' +
+  "The script's own object is never returned, and it must have an owner itself for this target to return anything.";
+SAI_TARGET_PARAM1_NAMES[SAI_TARGETS.SHARED_OWNER_ENTITIES] = 'Type';
+SAI_TARGET_PARAM2_NAMES[SAI_TARGETS.SHARED_OWNER_ENTITIES] = 'Entry';
+SAI_TARGET_PARAM3_NAMES[SAI_TARGETS.SHARED_OWNER_ENTITIES] = 'MaxDist';
+SAI_TARGET_PARAM1_TOOLTIPS[SAI_TARGETS.SHARED_OWNER_ENTITIES] = 'creature (1), gameobject (2)';
+SAI_TARGET_PARAM2_TOOLTIPS[SAI_TARGETS.SHARED_OWNER_ENTITIES] = '0: any entry';
+SAI_TARGET_PARAM3_TOOLTIPS[SAI_TARGETS.SHARED_OWNER_ENTITIES] = 'yards, 0: visibility range';

--- a/libs/shared/sai-editor/src/sai-comment-generator.service.spec.ts
+++ b/libs/shared/sai-editor/src/sai-comment-generator.service.spec.ts
@@ -1980,6 +1980,15 @@ describe('SaiCommentGeneratorService', () => {
         expected: `MockEntity - In Combat - Move To Formation`,
       },
       {
+        name: `SAI_ACTIONS.MOVE_TO_POS check target type (SAI_TARGETS.SHARED_OWNER_ENTITIES)`,
+        input: {
+          action_type: SAI_ACTIONS.MOVE_TO_POS,
+          target_type: SAI_TARGETS.SHARED_OWNER_ENTITIES,
+          target_param1: 0,
+        },
+        expected: `MockEntity - In Combat - Move To Shared Owner Entities`,
+      },
+      {
         name: `SAI_ACTIONS.MOVE_TO_POS check target type (unsupported target type)`,
         input: {
           action_type: SAI_ACTIONS.MOVE_TO_POS,

--- a/libs/shared/sai-editor/src/sai-comment-generator.service.ts
+++ b/libs/shared/sai-editor/src/sai-comment-generator.service.ts
@@ -91,6 +91,8 @@ export class SaiCommentGeneratorService {
         return 'Instance Storage';
       case SAI_TARGETS.FORMATION:
         return 'Formation';
+      case SAI_TARGETS.SHARED_OWNER_ENTITIES:
+        return 'Shared Owner Entities';
       default:
         return '[unsupported target type]';
     }


### PR DESCRIPTION
Aligns Keira3 with https://github.com/azerothcore/azerothcore-wotlk/pull/26902, which added the target type `SMART_TARGET_SHARED_OWNER_ENTITIES` (207).

It selects the creatures or gameobjects sharing the same owner, charmer or summoner as the object running the script, so it's handy when a spell summons both a creature and a gameobject and one needs to target the other.

Params, matching the core:

- `target_param1` Type: creature (1), gameobject (2)
- `target_param2` Entry: 0 = any
- `target_param3` MaxDist: yards, 0 = visibility range

Same shape as the `SMART_TARGET_FORMATION` addition in #3679: enum value, tooltips and param names, plus the comment generator label and its test case.

The FORMATION tooltip line right above got reflowed by prettier, it was over the 140 char limit already.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the “Shared Owner Entities” target type.
  - Added configuration details and tooltip guidance for selecting the target, entry, and maximum distance.
  - Improved the formation target tooltip for clarity.

- **Bug Fixes**
  - Updated generated action comments to correctly describe the new target type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->