### PR TITLE
refactor: import standalone translate declarables instead of TranslateModule

### DIFF
--- a/apps/keira/src/app/app.component.ts
+++ b/apps/keira/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { distinctUntilChanged } from 'rxjs';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import packageInfo from '../../../../package.json';
 
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective } from '@ngx-translate/core';
 
 import { ConnectionWindowComponent } from '@keira/main/connection-window';
 import { MainWindowComponent } from '@keira/main/main-window';
@@ -20,7 +20,7 @@ import { SubscriptionHandler } from '@keira/shared/utils';
   selector: 'keira-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
-  imports: [ConnectionWindowComponent, MainWindowComponent, TranslateModule],
+  imports: [ConnectionWindowComponent, MainWindowComponent, TranslateDirective],
 })
 export class AppComponent extends SubscriptionHandler implements OnInit {
   readonly KEIRA3_REPO_URL = KEIRA3_REPO_URL;

--- a/libs/features/conditions/src/edit-conditions/conditions.component.ts
+++ b/libs/features/conditions/src/edit-conditions/conditions.component.ts
@@ -22,7 +22,7 @@ import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent } from '@keira/shared/base-editor-components';
 import { FlagsSelectorBtnComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { getEnumKeys } from '@keira/shared/utils';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ConditionsHandlerService } from '../conditions-handler.service';
 import {
@@ -41,7 +41,8 @@ import { ConditionsService } from './conditions.service';
   templateUrl: './conditions.component.html',
   styleUrls: ['./conditions.component.scss'],
   imports: [
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/conditions/src/select-conditions/select-conditions.component.ts
+++ b/libs/features/conditions/src/select-conditions/select-conditions.component.ts
@@ -6,7 +6,7 @@ import { ConditionsHandlerService } from '../conditions-handler.service';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-components';
 
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ConditionsSearchService } from '@keira/shared/selectors';
 import { getEnumKeys } from '@keira/shared/utils';
@@ -15,7 +15,7 @@ import { getEnumKeys } from '@keira/shared/utils';
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './select-conditions.component.html',
   styleUrls: ['./select-conditions.component.scss'],
-  imports: [FormsModule, ReactiveFormsModule, TranslateModule, HighlightjsWrapperComponent, NgxDatatableModule],
+  imports: [FormsModule, ReactiveFormsModule, TranslateDirective, TranslatePipe, HighlightjsWrapperComponent, NgxDatatableModule],
 })
 export class SelectConditionsComponent extends SelectComplexKeyComponent<Conditions> implements OnInit {
   readonly CONDITION_SOURCE_TYPES = CONDITION_SOURCE_TYPES;

--- a/libs/features/creature/src/creature-default-trainer/creature-default-trainer.component.ts
+++ b/libs/features/creature/src/creature-default-trainer/creature-default-trainer.component.ts
@@ -3,7 +3,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CreatureDefaultTrainer } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureDefaultTrainerService } from './creature-default-trainer.service';
@@ -12,7 +12,7 @@ import { CreatureDefaultTrainerService } from './creature-default-trainer.servic
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-creature-default-trainer',
   templateUrl: './creature-default-trainer.component.html',
-  imports: [TopBarComponent, TranslateModule, QueryOutputComponent, FormsModule, ReactiveFormsModule, TooltipModule],
+  imports: [TopBarComponent, TranslateDirective, TranslatePipe, QueryOutputComponent, FormsModule, ReactiveFormsModule, TooltipModule],
 })
 export class CreatureDefaultTrainerComponent extends SingleRowEditorComponent<CreatureDefaultTrainer> {
   protected override readonly editorService = inject(CreatureDefaultTrainerService);

--- a/libs/features/creature/src/creature-equip-template/creature-equip-template.component.ts
+++ b/libs/features/creature/src/creature-equip-template/creature-equip-template.component.ts
@@ -4,7 +4,7 @@ import { CreatureEquipTemplate } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { IconComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { ItemSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureEquipTemplateService } from './creature-equip-template.service';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
@@ -16,7 +16,8 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
   styleUrls: ['./creature-equip-template.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-formations/creature-formations.component.ts
+++ b/libs/features/creature/src/creature-formations/creature-formations.component.ts
@@ -3,7 +3,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CreatureFormation } from '@keira/shared/acore-world-model';
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -15,7 +15,8 @@ import { CreatureFormationsService } from './creature-formations.service';
   templateUrl: './creature-formations.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-onkill-reputation/creature-onkill-reputation.component.ts
+++ b/libs/features/creature/src/creature-onkill-reputation/creature-onkill-reputation.component.ts
@@ -4,7 +4,7 @@ import { CreatureOnkillReputation, FACTION_RANK } from '@keira/shared/acore-worl
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { BooleanOptionSelectorComponent, FactionSelectorBtnComponent, GenericOptionSelectorComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureOnkillReputationService } from './creature-onkill-reputation.service';
@@ -16,7 +16,8 @@ import { CreatureOnkillReputationService } from './creature-onkill-reputation.se
   styleUrls: ['./creature-onkill-reputation.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-questitem/creature-questitem.component.ts
+++ b/libs/features/creature/src/creature-questitem/creature-questitem.component.ts
@@ -5,7 +5,7 @@ import { CreatureQuestitem } from '@keira/shared/acore-world-model';
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, IconComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { ItemSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureQuestitemService } from './creature-questitem.service';
@@ -17,7 +17,8 @@ import { CreatureQuestitemService } from './creature-questitem.service';
   styleUrls: ['./creature-questitem.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-spawn-addon/creature-spawn-addon.component.ts
+++ b/libs/features/creature/src/creature-spawn-addon/creature-spawn-addon.component.ts
@@ -4,7 +4,7 @@ import { CREATURE_ADDON_BYTES_1, CREATURE_ADDON_BYTES_2, CreatureSpawnAddon, EMO
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -17,7 +17,8 @@ import { CreatureSpawnAddonService } from './creature-spawn-addon.service';
   styleUrls: ['./creature-spawn-addon.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-template-addon/creature-template-addon.component.ts
+++ b/libs/features/creature/src/creature-template-addon/creature-template-addon.component.ts
@@ -10,7 +10,7 @@ import {
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTemplateAddonService } from './creature-template-addon.service';
@@ -22,7 +22,8 @@ import { CreatureTemplateAddonService } from './creature-template-addon.service'
   styleUrls: ['./creature-template-addon.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-template-model/creature-template-model.component.ts
+++ b/libs/features/creature/src/creature-template-model/creature-template-model.component.ts
@@ -4,7 +4,7 @@ import { CreatureTemplateModel } from '@keira/shared/acore-world-model';
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { Model3DViewerComponent, VIEWER_TYPE } from '@keira/shared/model-3d-viewer';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -17,7 +17,8 @@ import { CreatureTemplateModelService } from './creature-template-model.service'
   styleUrls: ['./creature-template-model.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-template-movement/creature-template-movement.component.ts
+++ b/libs/features/creature/src/creature-template-movement/creature-template-movement.component.ts
@@ -3,7 +3,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CREATURE_TEMPLATE_MOVEMENT_TABLE, CreatureTemplateMovement } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTemplateMovementService } from './creature-template-movement.service';
@@ -12,7 +12,7 @@ import { CreatureTemplateMovementService } from './creature-template-movement.se
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-creature-template-movement',
   templateUrl: './creature-template-movement.component.html',
-  imports: [TopBarComponent, TranslateModule, QueryOutputComponent, FormsModule, ReactiveFormsModule, TooltipModule],
+  imports: [TopBarComponent, TranslateDirective, TranslatePipe, QueryOutputComponent, FormsModule, ReactiveFormsModule, TooltipModule],
 })
 export class CreatureTemplateMovementComponent extends SingleRowEditorComponent<CreatureTemplateMovement> {
   protected override get docUrl(): string {

--- a/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.ts
+++ b/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.ts
@@ -8,7 +8,7 @@ import {
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -20,7 +20,8 @@ import { CreatureTemplateResistanceService } from './creature-template-resistanc
   templateUrl: './creature-template-resistance.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-template-spell/creature-template-spell.component.ts
+++ b/libs/features/creature/src/creature-template-spell/creature-template-spell.component.ts
@@ -6,7 +6,7 @@ import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, IconComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SqliteQueryService } from '@keira/shared/db-layer';
 import { SpellSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -18,7 +18,8 @@ import { CreatureTemplateSpellService } from './creature-template-spell.service'
   templateUrl: './creature-template-spell.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-template/creature-template.component.ts
+++ b/libs/features/creature/src/creature-template/creature-template.component.ts
@@ -30,7 +30,7 @@ import {
   GenericOptionSelectorComponent,
   SingleValueSelectorBtnComponent,
 } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTemplateService } from './creature-template.service';
@@ -41,7 +41,8 @@ import { CreatureTemplateService } from './creature-template.service';
   templateUrl: './creature-template.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-text/creature-text.component.ts
+++ b/libs/features/creature/src/creature-text/creature-text.component.ts
@@ -4,7 +4,7 @@ import { CreatureText, EMOTE, TEXT_RANGE, TEXT_TYPE } from '@keira/shared/acore-
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { GenericOptionSelectorComponent, LanguageSelectorBtnComponent, SoundEntriesSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -16,7 +16,8 @@ import { CreatureTextService } from './creature-text.service';
   templateUrl: './creature-text.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     TooltipModule,
     QueryOutputComponent,
     FormsModule,

--- a/libs/features/creature/src/npc-vendor/npc-vendor.component.ts
+++ b/libs/features/creature/src/npc-vendor/npc-vendor.component.ts
@@ -5,7 +5,7 @@ import { NpcVendor } from '@keira/shared/acore-world-model';
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, IconComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { ItemExtendedCostSelectorBtnComponent, ItemSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -18,7 +18,8 @@ import { NpcVendorService } from './npc-vendor.service';
   styleUrls: ['./npc-vendor.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/sai-creature/sai-creature.component.ts
+++ b/libs/features/creature/src/sai-creature/sai-creature.component.ts
@@ -3,7 +3,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { EditorButtonsComponent, QueryOutputComponent } from '@keira/shared/base-editor-components';
 import { SaiEditorComponent, SaiTopBarComponent, TimedActionlistComponent } from '@keira/shared/sai-editor';
 import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { SaiCreatureHandlerService } from '../sai-creature-handler.service';
@@ -17,7 +17,8 @@ import { AsyncPipe } from '@angular/common';
   styleUrls: ['../../../../../libs/shared/sai-editor/src/sai-editor.component.scss'],
   imports: [
     SaiTopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/select-creature/select-creature.component.ts
+++ b/libs/features/creature/src/select-creature/select-creature.component.ts
@@ -12,7 +12,7 @@ import { CreatureHandlerService } from '../creature-handler.service';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 
 @Component({
@@ -22,7 +22,8 @@ import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/dashboard/src/dashboard.component.ts
+++ b/libs/features/dashboard/src/dashboard.component.ts
@@ -6,7 +6,7 @@ import packageInfo from '../../../../package.json';
 import { FormsModule } from '@angular/forms';
 import { ClipboardModule } from 'ngx-clipboard';
 
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { SubscriptionHandler } from '@keira/shared/utils';
 import { MysqlQueryService, MysqlService } from '@keira/shared/db-layer';
 import { ConfigService } from '@keira/shared/common-services';
@@ -16,7 +16,7 @@ import { ConfigService } from '@keira/shared/common-services';
   selector: 'keira-home',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
-  imports: [TranslateModule, ClipboardModule, FormsModule],
+  imports: [TranslateDirective, TranslatePipe, ClipboardModule, FormsModule],
 })
 export class DashboardComponent extends SubscriptionHandler implements OnInit {
   protected coreVersions!: VersionRow;

--- a/libs/features/game-tele/src/select-game-tele/select-game-tele.component.ts
+++ b/libs/features/game-tele/src/select-game-tele/select-game-tele.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { SelectComponent } from '@keira/shared/base-abstract-classes';
 import { GAME_TELE_CUSTOM_STARTING_ID, GAME_TELE_ID, GAME_TELE_TABLE, GameTele } from '@keira/shared/acore-world-model';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { GameTeleHandlerService } from '../game-tele-handler.service';
 import { SelectGameTeleService } from './select-game-tele.service';
@@ -15,7 +15,8 @@ import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@
   imports: [
     FormsModule,
     ReactiveFormsModule,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     NgxDatatableModule,
     CreateComponent,
     HighlightjsWrapperComponent,

--- a/libs/features/gameobject/src/gameobject-loot-template/gameobject-loot-template.component.ts
+++ b/libs/features/gameobject/src/gameobject-loot-template/gameobject-loot-template.component.ts
@@ -3,7 +3,7 @@ import { GameobjectLootTemplate } from '@keira/shared/acore-world-model';
 import { LootTemplateIdComponent } from '@keira/shared/base-abstract-classes';
 import { TopBarComponent } from '@keira/shared/base-editor-components';
 import { LootEditorComponent } from '@keira/shared/loot-editor';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { QueryError } from 'mysql2';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
 import { GameobjectLootTemplateService } from './gameobject-loot-template.service';
@@ -12,7 +12,7 @@ import { GameobjectLootTemplateService } from './gameobject-loot-template.servic
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-gameobject-loot-template',
   templateUrl: './gameobject-loot-template.component.html',
-  imports: [TopBarComponent, TranslateModule, LootEditorComponent],
+  imports: [TopBarComponent, TranslateDirective, TranslatePipe, LootEditorComponent],
 })
 export class GameobjectLootTemplateComponent extends LootTemplateIdComponent<GameobjectLootTemplate> implements OnInit {
   private _type!: number;

--- a/libs/features/gameobject/src/gameobject-questitem/gameobject-questitem.component.ts
+++ b/libs/features/gameobject/src/gameobject-questitem/gameobject-questitem.component.ts
@@ -5,7 +5,7 @@ import { GameobjectQuestitem } from '@keira/shared/acore-world-model';
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, IconComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { ItemSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
 import { GameobjectQuestitemService } from './gameobject-questitem.service';
@@ -17,7 +17,8 @@ import { GameobjectQuestitemService } from './gameobject-questitem.service';
   styleUrls: ['./gameobject-questitem.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/gameobject/src/gameobject-spawn-addon/gameobject-spawn-addon.component.ts
+++ b/libs/features/gameobject/src/gameobject-spawn-addon/gameobject-spawn-addon.component.ts
@@ -4,7 +4,7 @@ import { GameobjectSpawnAddon, INVISIBILITY_TYPE } from '@keira/shared/acore-wor
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
@@ -16,7 +16,8 @@ import { GameobjectSpawnAddonService } from './gameobject-spawn-addon.service';
   templateUrl: './gameobject-spawn-addon.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/gameobject/src/gameobject-template-addon/gameobject-template-addon.component.ts
+++ b/libs/features/gameobject/src/gameobject-template-addon/gameobject-template-addon.component.ts
@@ -4,7 +4,7 @@ import { GAMEOBJECT_FLAGS, GameobjectTemplateAddon } from '@keira/shared/acore-w
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { FactionSelectorBtnComponent, FlagsSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
 import { GameobjectTemplateAddonService } from './gameobject-template-addon.service';
@@ -16,7 +16,8 @@ import { GameobjectTemplateAddonService } from './gameobject-template-addon.serv
   styleUrls: ['./gameobject-template-addon.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/gameobject/src/gameobject-template/gameobject-template.component.ts
+++ b/libs/features/gameobject/src/gameobject-template/gameobject-template.component.ts
@@ -6,7 +6,7 @@ import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor
 import { FieldDefinition } from '@keira/shared/constants';
 import { Model3DViewerComponent, VIEWER_TYPE } from '@keira/shared/model-3d-viewer';
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
 import { GameobjectTemplateService } from './gameobject-template.service';
@@ -18,7 +18,8 @@ import { GameobjectTemplateService } from './gameobject-template.service';
   styleUrls: ['./gameobject-template.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/gameobject/src/sai-gameobject/sai-gameobject.component.ts
+++ b/libs/features/gameobject/src/sai-gameobject/sai-gameobject.component.ts
@@ -3,7 +3,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { EditorButtonsComponent, QueryOutputComponent } from '@keira/shared/base-editor-components';
 import { SaiEditorComponent, SaiTopBarComponent, TimedActionlistComponent } from '@keira/shared/sai-editor';
 import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { SaiGameobjectHandlerService } from '../sai-gameobject-handler.service';
@@ -17,7 +17,8 @@ import { AsyncPipe } from '@angular/common';
   styleUrls: ['../../../../../libs/shared/sai-editor/src/sai-editor.component.scss'],
   imports: [
     SaiTopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/gameobject/src/select-gameobject/select-gameobject.component.ts
+++ b/libs/features/gameobject/src/select-gameobject/select-gameobject.component.ts
@@ -14,7 +14,7 @@ import { SelectGameobjectService } from './select-gameobject.service';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -22,7 +22,8 @@ import { TranslateModule } from '@ngx-translate/core';
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/gossip/src/gossip-menu-option/gossip-menu-option.component.ts
+++ b/libs/features/gossip/src/gossip-menu-option/gossip-menu-option.component.ts
@@ -4,7 +4,7 @@ import { GossipMenuOption, OPTION_ICON, OPTION_TYPE } from '@keira/shared/acore-
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { GenericOptionSelectorComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { GossipHandlerService } from '../gossip-handler.service';
@@ -17,7 +17,8 @@ import { GossipMenuOptionService } from './gossip-menu-option.service';
   templateUrl: './gossip-menu-option.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/gossip/src/gossip-menu/gossip-menu.component.ts
+++ b/libs/features/gossip/src/gossip-menu/gossip-menu.component.ts
@@ -6,7 +6,7 @@ import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { NpcTextSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { GossipHandlerService } from '../gossip-handler.service';
@@ -19,7 +19,8 @@ import { GossipMenuService } from './gossip-menu.service';
   styleUrls: ['./gossip-menu.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/gossip/src/select-gossip/select-gossip.component.ts
+++ b/libs/features/gossip/src/select-gossip/select-gossip.component.ts
@@ -6,7 +6,7 @@ import { SelectGossipService } from './select-gossip.service';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { AsyncPipe } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 
 @Component({
@@ -16,7 +16,8 @@ import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/item/src/item-enchantment/item-enchantment-template.component.ts
+++ b/libs/features/item/src/item-enchantment/item-enchantment-template.component.ts
@@ -6,7 +6,7 @@ import { ItemEnchantmentTemplateService } from './item-enchantment-template.serv
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -15,7 +15,8 @@ import { TranslateModule } from '@ngx-translate/core';
   styleUrls: ['./item-enchantment-template.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/item/src/item-template/item-template.component.ts
+++ b/libs/features/item/src/item-template/item-template.component.ts
@@ -42,7 +42,7 @@ import {
   SpellSelectorBtnComponent,
 } from '@keira/shared/selectors';
 import { compareObjFn } from '@keira/shared/utils';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { debounceTime, distinctUntilChanged } from 'rxjs';
 import { ItemHandlerService } from '../item-handler.service';
@@ -57,7 +57,8 @@ import { ItemTemplateService } from './item-template.service';
   styleUrls: ['./item-template.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/item/src/select-item/select-item.component.ts
+++ b/libs/features/item/src/select-item/select-item.component.ts
@@ -3,7 +3,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ITEM_TEMPLATE_CUSTOM_STARTING_ID, ITEM_TEMPLATE_ID, ITEM_TEMPLATE_TABLE, ItemTemplate } from '@keira/shared/acore-world-model';
 import { SelectComponent } from '@keira/shared/base-abstract-classes';
 import { CreateComponent, HighlightjsWrapperComponent, IconComponent, TopBarComponent } from '@keira/shared/base-editor-components';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { ItemHandlerService } from '../item-handler.service';
 import { SelectItemService } from './select-item.service';
@@ -15,7 +15,8 @@ import { SelectItemService } from './select-item.service';
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/other-loots/src/fishing-loot/fishing-loot-template.component.ts
+++ b/libs/features/other-loots/src/fishing-loot/fishing-loot-template.component.ts
@@ -4,14 +4,14 @@ import { FishingLootTemplate } from '@keira/shared/acore-world-model';
 import { FishingLootHandlerService } from './fishing-loot-handler.service';
 import { FishingLootTemplateService } from './fishing-loot-template.service';
 import { LootEditorComponent } from '@keira/shared/loot-editor';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective } from '@ngx-translate/core';
 import { TopBarComponent } from '@keira/shared/base-editor-components';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-fishing-loot-template',
   templateUrl: '../../../../shared/base-abstract-classes/src/components/editors/loot-template/loot-template.component.html',
-  imports: [TopBarComponent, TranslateModule, LootEditorComponent],
+  imports: [TopBarComponent, TranslateDirective, LootEditorComponent],
 })
 export class FishingLootTemplateComponent extends LootTemplateComponent<FishingLootTemplate> {
   protected override readonly editorService = inject(FishingLootTemplateService);

--- a/libs/features/other-loots/src/fishing-loot/select-fishing-loot.component.ts
+++ b/libs/features/other-loots/src/fishing-loot/select-fishing-loot.component.ts
@@ -11,7 +11,7 @@ import { SelectFishingLootService } from './select-fishing-loot.service';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 
 @Component({
@@ -20,7 +20,8 @@ import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/other-loots/src/mail-loot/mail-loot-template.component.ts
+++ b/libs/features/other-loots/src/mail-loot/mail-loot-template.component.ts
@@ -4,14 +4,14 @@ import { MailLootTemplate } from '@keira/shared/acore-world-model';
 import { MailLootHandlerService } from './mail-loot-handler.service';
 import { MailLootTemplateService } from './mail-loot-template.service';
 import { LootEditorComponent } from '@keira/shared/loot-editor';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective } from '@ngx-translate/core';
 import { TopBarComponent } from '@keira/shared/base-editor-components';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-mail-loot-template',
   templateUrl: '../../../../shared/base-abstract-classes/src/components/editors/loot-template/loot-template.component.html',
-  imports: [TopBarComponent, TranslateModule, LootEditorComponent],
+  imports: [TopBarComponent, TranslateDirective, LootEditorComponent],
 })
 export class MailLootTemplateComponent extends LootTemplateComponent<MailLootTemplate> {
   protected override readonly editorService = inject(MailLootTemplateService);

--- a/libs/features/other-loots/src/mail-loot/select-mail-loot.component.ts
+++ b/libs/features/other-loots/src/mail-loot/select-mail-loot.component.ts
@@ -10,7 +10,7 @@ import { MailLootHandlerService } from './mail-loot-handler.service';
 import { SelectMailLootService } from './select-mail-loot.service';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 
 @Component({
@@ -19,7 +19,8 @@ import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/other-loots/src/reference-loot/reference-loot-template.component.ts
+++ b/libs/features/other-loots/src/reference-loot/reference-loot-template.component.ts
@@ -4,14 +4,14 @@ import { ReferenceLootTemplate } from '@keira/shared/acore-world-model';
 import { ReferenceLootHandlerService } from './reference-loot-handler.service';
 import { ReferenceLootTemplateService } from './reference-loot-template.service';
 import { LootEditorComponent } from '@keira/shared/loot-editor';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective } from '@ngx-translate/core';
 import { TopBarComponent } from '@keira/shared/base-editor-components';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-reference-loot-template',
   templateUrl: '../../../../shared/base-abstract-classes/src/components/editors/loot-template/loot-template.component.html',
-  imports: [TopBarComponent, TranslateModule, LootEditorComponent],
+  imports: [TopBarComponent, TranslateDirective, LootEditorComponent],
 })
 export class ReferenceLootTemplateComponent extends LootTemplateComponent<ReferenceLootTemplate> {
   protected override readonly editorService = inject(ReferenceLootTemplateService);

--- a/libs/features/other-loots/src/reference-loot/select-reference-loot.component.ts
+++ b/libs/features/other-loots/src/reference-loot/select-reference-loot.component.ts
@@ -10,7 +10,7 @@ import { ReferenceLootHandlerService } from './reference-loot-handler.service';
 import { SelectReferenceLootService } from './select-reference-loot.service';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 
 @Component({
@@ -19,7 +19,8 @@ import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/other-loots/src/spell-loot/select-spell-loot.component.ts
+++ b/libs/features/other-loots/src/spell-loot/select-spell-loot.component.ts
@@ -10,7 +10,7 @@ import { SelectSpellLootService } from './select-spell-loot.service';
 import { SpellLootHandlerService } from './spell-loot-handler.service';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 
 @Component({
@@ -19,7 +19,8 @@ import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/other-loots/src/spell-loot/spell-loot-template.component.ts
+++ b/libs/features/other-loots/src/spell-loot/spell-loot-template.component.ts
@@ -3,7 +3,7 @@ import { LootTemplateComponent } from '@keira/shared/base-abstract-classes';
 import { SpellLootTemplate } from '@keira/shared/acore-world-model';
 import { SpellLootHandlerService } from './spell-loot-handler.service';
 import { SpellLootTemplateService } from './spell-loot-template.service';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective } from '@ngx-translate/core';
 import { TopBarComponent } from '@keira/shared/base-editor-components';
 import { LootEditorComponent } from '@keira/shared/loot-editor';
 
@@ -11,7 +11,7 @@ import { LootEditorComponent } from '@keira/shared/loot-editor';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-spell-loot-template',
   templateUrl: '../../../../shared/base-abstract-classes/src/components/editors/loot-template/loot-template.component.html',
-  imports: [TopBarComponent, TranslateModule, LootEditorComponent],
+  imports: [TopBarComponent, TranslateDirective, LootEditorComponent],
 })
 export class SpellLootTemplateComponent extends LootTemplateComponent<SpellLootTemplate> {
   protected override readonly editorService = inject(SpellLootTemplateService);

--- a/libs/features/quest/src/creature-questender/creature-questender.component.ts
+++ b/libs/features/quest/src/creature-questender/creature-questender.component.ts
@@ -5,7 +5,7 @@ import { CreatureQuestender } from '@keira/shared/acore-world-model';
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { CreatureSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -20,7 +20,8 @@ import { CreatureQuestenderService } from './creature-questender.service';
   styleUrls: ['./creature-questender.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/quest/src/creature-queststarter/creature-queststarter.component.ts
+++ b/libs/features/quest/src/creature-queststarter/creature-queststarter.component.ts
@@ -5,7 +5,7 @@ import { CreatureQueststarter } from '@keira/shared/acore-world-model';
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { CreatureSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -20,7 +20,8 @@ import { CreatureQueststarterService } from './creature-queststarter.service';
   styleUrls: ['./creature-queststarter.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/quest/src/gameobject-questender/gameobject-questender.component.ts
+++ b/libs/features/quest/src/gameobject-questender/gameobject-questender.component.ts
@@ -5,7 +5,7 @@ import { GameobjectQuestender } from '@keira/shared/acore-world-model';
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { GameobjectSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -20,7 +20,8 @@ import { GameobjectQuestenderService } from './gameobject-questender.service';
   styleUrls: ['./gameobject-questender.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/quest/src/gameobject-queststarter/gameobject-queststarter.component.ts
+++ b/libs/features/quest/src/gameobject-queststarter/gameobject-queststarter.component.ts
@@ -5,7 +5,7 @@ import { GameobjectQueststarter } from '@keira/shared/acore-world-model';
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { GameobjectSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -20,7 +20,8 @@ import { GameobjectQueststarterService } from './gameobject-queststarter.service
   styleUrls: ['./gameobject-queststarter.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/quest/src/quest-offer-reward/quest-offer-reward.component.ts
+++ b/libs/features/quest/src/quest-offer-reward/quest-offer-reward.component.ts
@@ -4,7 +4,7 @@ import { EMOTE, QuestOfferReward } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
@@ -18,7 +18,8 @@ import { QuestOfferRewardService } from './quest-offer-reward.service';
   styleUrls: ['./quest-offer-reward.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/quest/src/quest-request-items/quest-request-items.component.ts
+++ b/libs/features/quest/src/quest-request-items/quest-request-items.component.ts
@@ -4,7 +4,7 @@ import { EMOTE, QuestRequestItems } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
@@ -18,7 +18,8 @@ import { QuestRequestItemsService } from './quest-request-items.service';
   styleUrls: ['./quest-request-items.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/quest/src/quest-template-addon/quest-template-addon.component.ts
+++ b/libs/features/quest/src/quest-template-addon/quest-template-addon.component.ts
@@ -10,7 +10,7 @@ import {
   SkillSelectorBtnComponent,
   SpellSelectorBtnComponent,
 } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
@@ -24,7 +24,8 @@ import { QuestTemplateAddonService } from './quest-template-addon.service';
   styleUrls: ['./quest-template-addon.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/quest/src/quest-template-locale/quest-template-locale.component.ts
+++ b/libs/features/quest/src/quest-template-locale/quest-template-locale.component.ts
@@ -4,7 +4,7 @@ import { QUEST_LOCALE, QuestTemplateLocale } from '@keira/shared/acore-world-mod
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -18,7 +18,8 @@ import { QuestTemplateLocaleService } from './quest-template-locale.service';
   templateUrl: './quest-template-locale.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/quest/src/quest-template/quest-template.component.ts
+++ b/libs/features/quest/src/quest-template/quest-template.component.ts
@@ -11,7 +11,7 @@ import {
   SingleValueSelectorBtnComponent,
   SpellSelectorBtnComponent,
 } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
@@ -25,7 +25,8 @@ import { QuestTemplateService } from './quest-template.service';
   styleUrls: ['./quest-template.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/quest/src/select-quest/select-quest.component.ts
+++ b/libs/features/quest/src/select-quest/select-quest.component.ts
@@ -7,7 +7,7 @@ import { NgxDatatableModule } from '@siemens/ngx-datatable';
 
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -16,7 +16,8 @@ import { TranslateModule } from '@ngx-translate/core';
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/smart-scripts/src/sai-search-entity/sai-search-entity.component.ts
+++ b/libs/features/smart-scripts/src/sai-search-entity/sai-search-entity.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { SAI_TYPES, SmartScripts } from '@keira/shared/acore-world-model';
 import { WIKI_BASE_URL } from '@keira/shared/constants';
 import { CreatureSelectorBtnComponent, GameobjectSelectorBtnComponent } from '@keira/shared/selectors';
@@ -13,7 +13,7 @@ import { getEnumKeys, ModelForm } from '@keira/shared/utils';
   selector: 'keira-sai-search-entity',
   templateUrl: './sai-search-entity.component.html',
   styleUrls: ['./sai-search-entity.component.scss'],
-  imports: [FormsModule, ReactiveFormsModule, TranslateModule, CreatureSelectorBtnComponent, GameobjectSelectorBtnComponent],
+  imports: [FormsModule, ReactiveFormsModule, TranslatePipe, CreatureSelectorBtnComponent, GameobjectSelectorBtnComponent],
 })
 export class SaiSearchEntityComponent {
   private readonly handlerService = inject(SaiHandlerService);

--- a/libs/features/smart-scripts/src/sai-search-existing/sai-search-existing.component.ts
+++ b/libs/features/smart-scripts/src/sai-search-existing/sai-search-existing.component.ts
@@ -4,7 +4,7 @@ import { SAI_TYPES, SmartScripts } from '@keira/shared/acore-world-model';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-components';
 
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SaiHandlerService } from '@keira/shared/sai-editor';
 import { SaiSearchService } from '@keira/shared/selectors';
@@ -15,7 +15,7 @@ import { getEnumKeys } from '@keira/shared/utils';
   selector: 'keira-sai-search-existing',
   templateUrl: './sai-search-existing.component.html',
   styleUrls: ['./sai-search-existing.component.scss'],
-  imports: [FormsModule, ReactiveFormsModule, TranslateModule, HighlightjsWrapperComponent, NgxDatatableModule],
+  imports: [FormsModule, ReactiveFormsModule, TranslateDirective, TranslatePipe, HighlightjsWrapperComponent, NgxDatatableModule],
 })
 export class SaiSearchExistingComponent extends SelectComplexKeyComponent<SmartScripts> {
   readonly SAI_SEARCH_TYPES = SAI_TYPES;

--- a/libs/features/spell/src/select-spell/select-spell.component.ts
+++ b/libs/features/spell/src/select-spell/select-spell.component.ts
@@ -15,7 +15,7 @@ import { NgxDatatableModule } from '@siemens/ngx-datatable';
 
 import { CreateComponent, HighlightjsWrapperComponent, IconComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,7 +23,8 @@ import { TranslateModule } from '@ngx-translate/core';
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/spell/src/spell-dbc/base/spell-dbc-base.component.ts
+++ b/libs/features/spell/src/spell-dbc/base/spell-dbc-base.component.ts
@@ -14,14 +14,22 @@ import {
 } from '@keira/shared/acore-world-model';
 import { FlagsSelectorBtnComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { ModelForm } from '@keira/shared/utils';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-spell-dbc-base',
   templateUrl: './spell-dbc-base.component.html',
-  imports: [FormsModule, ReactiveFormsModule, TranslateModule, TooltipModule, SingleValueSelectorBtnComponent, FlagsSelectorBtnComponent],
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    TranslateDirective,
+    TranslatePipe,
+    TooltipModule,
+    SingleValueSelectorBtnComponent,
+    FlagsSelectorBtnComponent,
+  ],
 })
 export class SpellDbcBaseComponent {
   readonly SPELL_DBC_SCHOOL_OPTIONS = SPELL_SCHOOL_MASK;

--- a/libs/features/spell/src/spell-dbc/effects/spell-dbc-effects.component.ts
+++ b/libs/features/spell/src/spell-dbc/effects/spell-dbc-effects.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SPELL_DBC_PROC_FLAGS, SPELL_DBC_TARGETS, SpellDbc } from '@keira/shared/acore-world-model';
 import { ModelForm } from '@keira/shared/utils';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { SpellDbcSpellEffectComponent } from './spell-dbc-spell-effect/spell-dbc-spell-effect.component';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
@@ -19,7 +19,7 @@ import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
     TooltipModule,
     TabsModule,
     SpellDbcSpellEffectComponent,
-    TranslateModule,
+    TranslatePipe,
   ],
 })
 export class SpellDbcEffectsComponent {

--- a/libs/features/spell/src/spell-dbc/effects/spell-dbc-spell-effect/spell-dbc-spell-effect.component.ts
+++ b/libs/features/spell/src/spell-dbc/effects/spell-dbc-spell-effect/spell-dbc-spell-effect.component.ts
@@ -11,13 +11,21 @@ import { ModelForm } from '@keira/shared/utils';
 import { SpellDbcSpellEffectFieldPrefix } from './spell-dbc-spell-effect.model';
 import { FlagsSelectorBtnComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-spell-dbc-spell-effect',
   templateUrl: './spell-dbc-spell-effect.component.html',
-  imports: [FormsModule, ReactiveFormsModule, TranslateModule, SingleValueSelectorBtnComponent, TooltipModule, FlagsSelectorBtnComponent],
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    TranslateDirective,
+    TranslatePipe,
+    SingleValueSelectorBtnComponent,
+    TooltipModule,
+    FlagsSelectorBtnComponent,
+  ],
 })
 export class SpellDbcSpellEffectComponent {
   @Input({ required: true }) formGroup!: FormGroup<ModelForm<SpellDbc>>;

--- a/libs/features/spell/src/spell-dbc/flags/spell-dbc-flags.component.ts
+++ b/libs/features/spell/src/spell-dbc/flags/spell-dbc-flags.component.ts
@@ -13,14 +13,14 @@ import {
 import { ModelForm } from '@keira/shared/utils';
 
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-spell-dbc-flags',
   templateUrl: './spell-dbc-flags.component.html',
-  imports: [FormsModule, ReactiveFormsModule, TranslateModule, FlagsSelectorBtnComponent, TooltipModule],
+  imports: [FormsModule, ReactiveFormsModule, TranslateDirective, TranslatePipe, FlagsSelectorBtnComponent, TooltipModule],
 })
 export class SpellDbcFlagsComponent {
   readonly SPELL_DBC_ATTRIBUTES_FLAGS = SPELL_DBC_ATTRIBUTES_FLAGS;

--- a/libs/features/spell/src/spell-dbc/items/spell-dbc-items.component.ts
+++ b/libs/features/spell/src/spell-dbc/items/spell-dbc-items.component.ts
@@ -4,7 +4,7 @@ import { ITEM_CLASS, SPELL_DBC_INVENTORY_TYPE, SPELL_DBC_ITEM_SUBCLASS, SpellDbc
 import { ModelForm } from '@keira/shared/utils';
 
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { FlagsSelectorBtnComponent, ItemSelectorBtnComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 
 @Component({
@@ -14,7 +14,8 @@ import { FlagsSelectorBtnComponent, ItemSelectorBtnComponent, SingleValueSelecto
   imports: [
     FormsModule,
     ReactiveFormsModule,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     SingleValueSelectorBtnComponent,
     TooltipModule,
     FlagsSelectorBtnComponent,

--- a/libs/features/spell/src/spell-dbc/misc/spell-dbc-misc.component.ts
+++ b/libs/features/spell/src/spell-dbc/misc/spell-dbc-misc.component.ts
@@ -2,14 +2,14 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ModelForm } from '@keira/shared/utils';
 import { SpellDbc } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-spell-dbc-misc',
   templateUrl: './spell-dbc-misc.component.html',
-  imports: [FormsModule, ReactiveFormsModule, TooltipModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, TooltipModule, TranslatePipe],
 })
 export class SpellDbcMiscComponent {
   readonly formGroup = input.required<FormGroup<ModelForm<SpellDbc>>>();

--- a/libs/features/spell/src/spell-dbc/spell-dbc.component.ts
+++ b/libs/features/spell/src/spell-dbc/spell-dbc.component.ts
@@ -11,7 +11,7 @@ import { SpellDbcEffectsComponent } from './effects/spell-dbc-effects.component'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SpellDbcBaseComponent } from './base/spell-dbc-base.component';
 import { TabsModule } from 'ngx-bootstrap/tabs';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective } from '@ngx-translate/core';
 
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 
@@ -21,7 +21,7 @@ import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor
   templateUrl: './spell-dbc.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
     QueryOutputComponent,
     TabsModule,
     SpellDbcBaseComponent,

--- a/libs/features/spell/src/spell-dbc/texts/spell-dbc-texts.component.ts
+++ b/libs/features/spell/src/spell-dbc/texts/spell-dbc-texts.component.ts
@@ -3,7 +3,7 @@ import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ModelForm } from '@keira/shared/utils';
 import { SpellDbc } from '@keira/shared/acore-world-model';
 import { LOCALES } from './spell-dbc-texts.model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { SpellDbcLocaleComponent } from './spell-dbc-locale/spell-dbc-locale.component';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
@@ -13,7 +13,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-spell-dbc-texts',
   templateUrl: './spell-dbc-texts.component.html',
-  imports: [FormsModule, ReactiveFormsModule, TooltipModule, TabsModule, SpellDbcLocaleComponent, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, TooltipModule, TabsModule, SpellDbcLocaleComponent, TranslatePipe],
 })
 export class SpellDbcTextsComponent {
   readonly LOCALES = LOCALES;

--- a/libs/features/sql-editor/src/sql-editor.component.ts
+++ b/libs/features/sql-editor/src/sql-editor.component.ts
@@ -5,7 +5,7 @@ import { TableRow } from '@keira/shared/constants';
 import { QueryError } from 'mysql2';
 import { ClipboardService } from 'ngx-clipboard';
 import { SqlEditorService } from './sql-editor.service';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 
 import { FormsModule } from '@angular/forms';
@@ -20,7 +20,7 @@ import { CodeEditor } from '@acrodata/code-editor';
   selector: 'keira-sql-editor',
   templateUrl: './sql-editor.component.html',
   styleUrls: ['./sql-editor.component.scss'],
-  imports: [CodeEditor, TooltipModule, FormsModule, QueryErrorComponent, NgxDatatableModule, TranslateModule],
+  imports: [CodeEditor, TooltipModule, FormsModule, QueryErrorComponent, NgxDatatableModule, TranslatePipe],
 })
 export class SqlEditorComponent extends SubscriptionHandler implements OnInit {
   private readonly mysqlQueryService = inject(MysqlQueryService);

--- a/libs/features/texts/src/acore-string/acore-string.component.ts
+++ b/libs/features/texts/src/acore-string/acore-string.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { AcoreString } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { AcoreStringHandlerService } from './acore-string-handler.service';
 import { AcoreStringService } from './acore-string.service';
@@ -11,7 +11,7 @@ import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './acore-string.component.html',
-  imports: [TranslateModule, ReactiveFormsModule, TooltipModule, QueryOutputComponent, TopBarComponent],
+  imports: [TranslateDirective, TranslatePipe, ReactiveFormsModule, TooltipModule, QueryOutputComponent, TopBarComponent],
 })
 export class AcoreStringComponent extends SingleRowEditorComponent<AcoreString> {
   override readonly editorService = inject(AcoreStringService);

--- a/libs/features/texts/src/acore-string/select-acore-string.component.ts
+++ b/libs/features/texts/src/acore-string/select-acore-string.component.ts
@@ -3,7 +3,7 @@ import { SelectComponent } from '@keira/shared/base-abstract-classes';
 import { ACORE_STRING_CUSTOM_STARTING_ID, ACORE_STRING_ENTRY, ACORE_STRING_TABLE, AcoreString } from '@keira/shared/acore-world-model';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { SelectAcoreStringService } from './select-acore-string.service';
 import { AcoreStringHandlerService } from './acore-string-handler.service';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
@@ -12,7 +12,8 @@ import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './select-acore-string.component.html',
   imports: [
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     NgxDatatableModule,

--- a/libs/features/texts/src/broadcast-text/broadcast-text.component.ts
+++ b/libs/features/texts/src/broadcast-text/broadcast-text.component.ts
@@ -4,7 +4,7 @@ import { BroadcastText, EMOTE } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { LanguageSelectorBtnComponent, SingleValueSelectorBtnComponent, SoundEntriesSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { BroadcastTextHandlerService } from './broadcast-text-handler.service';
 import { BroadcastTextService } from './broadcast-text.service';
@@ -14,7 +14,8 @@ import { BroadcastTextService } from './broadcast-text.service';
   templateUrl: './broadcast-text.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     ReactiveFormsModule,
     SingleValueSelectorBtnComponent,

--- a/libs/features/texts/src/broadcast-text/select-broadcast-text.component.ts
+++ b/libs/features/texts/src/broadcast-text/select-broadcast-text.component.ts
@@ -3,7 +3,7 @@ import { SelectComponent } from '@keira/shared/base-abstract-classes';
 import { BroadcastText, BROADCAST_TEXT_CUSTOM_STARTING_ID, BROADCAST_TEXT_TABLE, BROADCAST_TEXT_ID } from '@keira/shared/acore-world-model';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SelectBroadcastTextService } from './select-broadcast-text.service';
 import { BroadcastTextHandlerService } from './broadcast-text-handler.service';
@@ -14,7 +14,8 @@ import { BroadcastTextHandlerService } from './broadcast-text-handler.service';
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/texts/src/npc-text/npc-text-fields-group.component.ts
+++ b/libs/features/texts/src/npc-text/npc-text-fields-group.component.ts
@@ -3,14 +3,14 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { EMOTE, NpcText } from '@keira/shared/acore-world-model';
 import { LanguageSelectorBtnComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { ModelForm } from '@keira/shared/utils';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './npc-text-fields-group.component.html',
   selector: 'keira-npc-text-fields-group',
-  imports: [TranslateModule, ReactiveFormsModule, SingleValueSelectorBtnComponent, TooltipModule, LanguageSelectorBtnComponent],
+  imports: [TranslatePipe, ReactiveFormsModule, SingleValueSelectorBtnComponent, TooltipModule, LanguageSelectorBtnComponent],
 })
 export class NpcTextFieldsGroupComponent {
   formGroup = input.required<FormGroup<ModelForm<NpcText>>>();

--- a/libs/features/texts/src/npc-text/npc-text.component.ts
+++ b/libs/features/texts/src/npc-text/npc-text.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective } from '@ngx-translate/core';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { NpcTextService } from './npc-text.service';
 import { NpcTextHandlerService } from './npc-text-handler.service';
@@ -12,7 +12,7 @@ import { NpcTextFieldsGroupComponent } from './npc-text-fields-group.component';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './npc-text.component.html',
-  imports: [TopBarComponent, TranslateModule, QueryOutputComponent, ReactiveFormsModule, TooltipModule, NpcTextFieldsGroupComponent],
+  imports: [TopBarComponent, TranslateDirective, QueryOutputComponent, ReactiveFormsModule, TooltipModule, NpcTextFieldsGroupComponent],
 })
 export class NpcTextComponent extends SingleRowEditorComponent<NpcText> {
   protected override readonly editorService = inject(NpcTextService);

--- a/libs/features/texts/src/npc-text/select-npc-text.component.ts
+++ b/libs/features/texts/src/npc-text/select-npc-text.component.ts
@@ -3,7 +3,7 @@ import { SelectComponent } from '@keira/shared/base-abstract-classes';
 import { NpcText, NPC_TEXT_CUSTOM_STARTING_ID, NPC_TEXT_TABLE, NPC_TEXT_ID } from '@keira/shared/acore-world-model';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SelectNpcTextService } from './select-npc-text.service';
 import { NpcTextHandlerService } from './npc-text-handler.service';
@@ -14,7 +14,8 @@ import { NpcTextHandlerService } from './npc-text-handler.service';
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/texts/src/page-text/page-text.component.ts
+++ b/libs/features/texts/src/page-text/page-text.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { PageTextService } from './page-text.service';
 import { PageTextHandlerService } from './page-text-handler.service';
@@ -11,7 +11,7 @@ import { PageText } from '@keira/shared/acore-world-model';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './page-text.component.html',
-  imports: [TopBarComponent, TranslateModule, QueryOutputComponent, ReactiveFormsModule, TooltipModule],
+  imports: [TopBarComponent, TranslateDirective, TranslatePipe, QueryOutputComponent, ReactiveFormsModule, TooltipModule],
 })
 export class PageTextComponent extends SingleRowEditorComponent<PageText> {
   protected override readonly editorService = inject(PageTextService);

--- a/libs/features/texts/src/page-text/select-page-text.component.ts
+++ b/libs/features/texts/src/page-text/select-page-text.component.ts
@@ -3,7 +3,7 @@ import { SelectComponent } from '@keira/shared/base-abstract-classes';
 import { PageText, PAGE_TEXT_CUSTOM_STARTING_ID, PAGE_TEXT_TABLE, PAGE_TEXT_ID } from '@keira/shared/acore-world-model';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SelectPageTextService } from './select-page-text.service';
 import { PageTextHandlerService } from './page-text-handler.service';
@@ -14,7 +14,8 @@ import { PageTextHandlerService } from './page-text-handler.service';
   imports: [
     TopBarComponent,
     CreateComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     HighlightjsWrapperComponent,

--- a/libs/features/trainer/src/edit-trainer/trainer.component.ts
+++ b/libs/features/trainer/src/edit-trainer/trainer.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TRAINER_TYPE, Trainer } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { TrainerService } from './trainer.service';
 import { TrainerHandlerService } from '../trainer-handler.service';
@@ -15,7 +15,8 @@ import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
   templateUrl: './trainer.component.html',
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
     TooltipModule,

--- a/libs/features/trainer/src/select-trainer/select-trainer.component.ts
+++ b/libs/features/trainer/src/select-trainer/select-trainer.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { SelectComponent } from '@keira/shared/base-abstract-classes';
 import { TRAINER_ID, TRAINER_TABLE, Trainer } from '@keira/shared/acore-world-model';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TrainerHandlerService } from '../trainer-handler.service';
 import { SelectTrainerService } from './select-trainer.service';
@@ -15,7 +15,8 @@ import { CreateComponent, HighlightjsWrapperComponent, TopBarComponent } from '@
   imports: [
     FormsModule,
     ReactiveFormsModule,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     NgxDatatableModule,
     CreateComponent,
     HighlightjsWrapperComponent,

--- a/libs/features/trainer/src/trainer-spell/trainer-spell.component.ts
+++ b/libs/features/trainer/src/trainer-spell/trainer-spell.component.ts
@@ -6,7 +6,7 @@ import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, IconComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SqliteQueryService } from '@keira/shared/db-layer';
 import { SkillSelectorBtnComponent, SpellSelectorBtnComponent } from '@keira/shared/selectors';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { TrainerHandlerService } from '../trainer-handler.service';
@@ -19,7 +19,8 @@ import { TrainerSpellService } from './trainer-spell.service';
   styleUrls: ['./trainer-spell.component.scss'],
   imports: [
     TopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/unused-guid-search/src/unused-guid-search.component.ts
+++ b/libs/features/unused-guid-search/src/unused-guid-search.component.ts
@@ -20,14 +20,14 @@ import {
   ACORE_STRING_ENTRY,
 } from '@keira/shared/acore-world-model';
 import { UnusedGuidService, DbOptions, MAX_INT_UNSIGNED_VALUE } from './unused-guid-search.service';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-features-unused-guid-search',
   templateUrl: './unused-guid-search.component.html',
   styleUrl: './unused-guid-search.component.scss',
-  imports: [FormsModule, ReactiveFormsModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, TranslatePipe],
 })
 export class UnusedGuidSearchComponent {
   private readonly destroyRef = inject(DestroyRef);

--- a/libs/main/connection-window/src/connection-window.component.ts
+++ b/libs/main/connection-window/src/connection-window.component.ts
@@ -5,7 +5,7 @@ import { QueryError } from 'mysql2';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import packageInfo from '../../../../package.json';
 
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
@@ -25,7 +25,8 @@ import { ModelForm, SubscriptionHandler } from '@keira/shared/utils';
     FormsModule,
     ReactiveFormsModule,
     BsDropdownModule,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     TooltipModule,
     QueryErrorComponent,
     SwitchLanguageComponent,

--- a/libs/main/main-window/src/sidebar/logout-btn/logout-btn.component.ts
+++ b/libs/main/main-window/src/sidebar/logout-btn/logout-btn.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { SubscriptionHandler } from '@keira/shared/utils';
 import { LoginConfigService } from '@keira/shared/login-config';
@@ -12,7 +12,7 @@ import { ModalConfirmComponent } from '@keira/shared/base-editor-components';
   selector: 'keira-logout-btn',
   templateUrl: './logout-btn.component.html',
   styleUrls: ['./logout-btn.component.scss'],
-  imports: [TranslateModule],
+  imports: [TranslatePipe],
 })
 export class LogoutBtnComponent extends SubscriptionHandler {
   public modalRef!: BsModalRef;

--- a/libs/main/main-window/src/sidebar/sidebar.component.ts
+++ b/libs/main/main-window/src/sidebar/sidebar.component.ts
@@ -30,7 +30,7 @@ import { LocationService } from '@keira/shared/common-services';
 import { MysqlService } from '@keira/shared/db-layer';
 import { SaiHandlerService } from '@keira/shared/sai-editor';
 import { SwitchLanguageComponent } from '@keira/shared/switch-language';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { LogoutBtnComponent } from './logout-btn/logout-btn.component';
 import { MenuStats, ROUTE_MENUS } from './sidebar.model';
 import { SidebarService } from './sidebar.service';
@@ -54,7 +54,8 @@ const animationTime = 200;
     SwitchLanguageComponent,
     LogoutBtnComponent,
     RouterLink,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     RouterLinkActive,
     UnsavedIconComponent,
     TitleCasePipe,

--- a/libs/main/main-window/src/sidebar/unsaved-icon/unsaved-icon.component.ts
+++ b/libs/main/main-window/src/sidebar/unsaved-icon/unsaved-icon.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 @Component({
@@ -7,6 +7,6 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
   selector: 'keira-unsaved-icon',
   templateUrl: './unsaved-icon.component.html',
   styleUrls: ['./unsaved-icon.component.scss'],
-  imports: [TooltipModule, TranslateModule],
+  imports: [TooltipModule, TranslatePipe],
 })
 export class UnsavedIconComponent {}

--- a/libs/shared/base-editor-components/src/create/create.component.ts
+++ b/libs/shared/base-editor-components/src/create/create.component.ts
@@ -4,7 +4,7 @@ import { HandlerService } from '@keira/shared/base-abstract-classes';
 import { TableRow } from '@keira/shared/constants';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SubscriptionHandler } from '@keira/shared/utils';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { QueryError } from 'mysql2';
 
 const MAX_INT_UNSIGNED_VALUE = 4294967295;
@@ -13,7 +13,7 @@ const MAX_INT_UNSIGNED_VALUE = 4294967295;
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-create',
   templateUrl: './create.component.html',
-  imports: [TranslateModule, FormsModule],
+  imports: [TranslateDirective, TranslatePipe, FormsModule],
 })
 export class CreateComponent<T extends TableRow> extends SubscriptionHandler implements OnInit {
   @Input({ required: true }) entityTable!: string;

--- a/libs/shared/base-editor-components/src/editor-buttons/editor-buttons.component.ts
+++ b/libs/shared/base-editor-components/src/editor-buttons/editor-buttons.component.ts
@@ -1,12 +1,12 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-editor-buttons',
   templateUrl: './editor-buttons.component.html',
-  imports: [TranslateModule],
+  imports: [TranslatePipe],
 })
 export class EditorButtonsComponent {
   readonly selectedRowId = input.required<string | number | undefined>();

--- a/libs/shared/base-editor-components/src/modal-confirm/modal-confirm.component.ts
+++ b/libs/shared/base-editor-components/src/modal-confirm/modal-confirm.component.ts
@@ -1,13 +1,13 @@
 import { BsModalRef } from 'ngx-bootstrap/modal';
 import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
 import { Subject } from 'rxjs';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective } from '@ngx-translate/core';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-modal-confirm',
   templateUrl: './modal-confirm.component.html',
-  imports: [TranslateModule],
+  imports: [TranslateDirective],
 })
 export class ModalConfirmComponent implements OnInit {
   private readonly _bsModalRef = inject(BsModalRef);

--- a/libs/shared/base-editor-components/src/query-output/query-output.component.ts
+++ b/libs/shared/base-editor-components/src/query-output/query-output.component.ts
@@ -15,7 +15,7 @@ import { FormsModule } from '@angular/forms';
 import { EditorService } from '@keira/shared/base-abstract-classes';
 import { TableRow } from '@keira/shared/constants';
 import { SubscriptionHandler } from '@keira/shared/utils';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { ClipboardService } from 'ngx-clipboard';
 import { filter } from 'rxjs';
@@ -29,7 +29,7 @@ import { QueryError } from 'mysql2';
   selector: 'keira-query-output',
   templateUrl: './query-output.component.html',
   styleUrls: ['./query-output.component.scss'],
-  imports: [FormsModule, HighlightjsWrapperComponent, QueryErrorComponent, TranslateModule],
+  imports: [FormsModule, HighlightjsWrapperComponent, QueryErrorComponent, TranslatePipe],
 })
 export class QueryOutputComponent<T extends TableRow> extends SubscriptionHandler {
   private readonly clipboardService = inject(ClipboardService);

--- a/libs/shared/loot-editor/src/loot-editor.component.ts
+++ b/libs/shared/loot-editor/src/loot-editor.component.ts
@@ -11,7 +11,7 @@ import { DTCFG } from '@keira/shared/config';
 import { WIKI_BASE_URL } from '@keira/shared/constants';
 import { FlagsSelectorBtnComponent, ItemSelectorBtnComponent } from '@keira/shared/selectors';
 import { compareObjFn, SubscriptionHandler } from '@keira/shared/utils';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ReferenceViewerComponent } from './reference-viewer.component';
@@ -33,7 +33,7 @@ import { ReferenceViewerComponent } from './reference-viewer.component';
     NgxDatatableModule,
     ReferenceViewerComponent,
     AsyncPipe,
-    TranslateModule,
+    TranslatePipe,
   ],
 })
 export class LootEditorComponent<T extends LootTemplate> extends SubscriptionHandler implements OnInit {

--- a/libs/shared/sai-editor/src/sai-editor.component.ts
+++ b/libs/shared/sai-editor/src/sai-editor.component.ts
@@ -70,7 +70,7 @@ import { TimedActionlistComponent } from './timed-actionlist/timed-actionlist.co
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { SaiTopBarComponent } from './sai-top-bar/sai-top-bar.component';
 import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
@@ -86,7 +86,8 @@ import { AsyncPipe } from '@angular/common';
   styleUrls: ['./sai-editor.component.scss'],
   imports: [
     SaiTopBarComponent,
-    TranslateModule,
+    TranslateDirective,
+    TranslatePipe,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/shared/selectors/src/selectors/area-selector/area-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/area-selector/area-selector-modal.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { AREA_ID, Area } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { AreaSearchService } from '../../search/area-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -12,7 +12,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-area-selector-modal',
   templateUrl: './area-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class AreaSelectorModalComponent extends SearchSelectorModalComponent<Area> {
   protected entityIdField = AREA_ID;

--- a/libs/shared/selectors/src/selectors/base-selector/base-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/base-selector/base-selector-btn.component.spec.ts
@@ -1,5 +1,4 @@
 import { vi } from 'vitest';
-import { CommonModule } from '@angular/common';
 import { NgModule, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -17,7 +16,6 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
 @NgModule({
   imports: [
     ModalModule,
-    CommonModule,
     BrowserModule,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/shared/selectors/src/selectors/boolean-option-selector/boolean-option-selector.component.ts
+++ b/libs/shared/selectors/src/selectors/boolean-option-selector/boolean-option-selector.component.ts
@@ -1,12 +1,12 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-boolean-option-selector',
   templateUrl: './boolean-option-selector.component.html',
-  imports: [ReactiveFormsModule, TranslateModule],
+  imports: [ReactiveFormsModule, TranslatePipe],
 })
 export class BooleanOptionSelectorComponent {
   readonly control = input.required<FormControl>();

--- a/libs/shared/selectors/src/selectors/creature-selector/creature-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/creature-selector/creature-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { CREATURE_TEMPLATE_ID, CreatureTemplate } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { CreatureSearchService } from '../../search/creature-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-creature-selector-modal',
   templateUrl: './creature-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class CreatureSelectorModalComponent extends SearchSelectorModalComponent<CreatureTemplate> {
   protected entityIdField = CREATURE_TEMPLATE_ID;

--- a/libs/shared/selectors/src/selectors/faction-selector/faction-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/faction-selector/faction-selector-modal.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { Faction, FACTION_ID } from '@keira/shared/acore-world-model';
 import { FactionSearchService } from '../../search/faction-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 
 import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-components';
@@ -13,7 +13,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-faction-selector-modal',
   templateUrl: './faction-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class FactionSelectorModalComponent extends SearchSelectorModalComponent<Faction> {
   protected entityIdField = FACTION_ID;

--- a/libs/shared/selectors/src/selectors/faction-selector/quest-faction-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/faction-selector/quest-faction-selector-modal.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { Faction, FACTION_SEARCH_FIELDS } from '@keira/shared/acore-world-model';
 import { FactionSearchService } from '../../search/faction-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-components';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -12,7 +12,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-quest-faction-selector-modal',
   templateUrl: './faction-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class QuestFactionSelectorModalComponent extends SearchSelectorModalComponent<Faction> {
   protected entityIdField = FACTION_SEARCH_FIELDS[1];

--- a/libs/shared/selectors/src/selectors/flags-selector/flags-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/flags-selector/flags-selector-modal.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/cor
 import { BaseSelectorModalComponent } from '../base-selector/base-selector-modal.component';
 import { FlagsService } from './flags.service';
 import { FlagsModalConfig } from './flags-selector.model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective } from '@ngx-translate/core';
 import { UiSwitchModule } from 'ngx-ui-switch';
 
 @Component({
@@ -11,7 +11,7 @@ import { UiSwitchModule } from 'ngx-ui-switch';
   selector: 'keira-flags-selector-modal',
   templateUrl: './flags-selector-modal.component.html',
   styleUrls: ['./flags-selector-modal.component.scss'],
-  imports: [UiSwitchModule, TranslateModule],
+  imports: [UiSwitchModule, TranslateDirective],
 })
 export class FlagsSelectorModalComponent extends BaseSelectorModalComponent<FlagsModalConfig> implements OnInit {
   readonly pow = Math.pow;

--- a/libs/shared/selectors/src/selectors/game-tele-selector/game-tele-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/game-tele-selector/game-tele-selector-modal.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { GAME_TELE_ID, GameTele } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -11,7 +11,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-game-tele-selector-modal',
   templateUrl: './game-tele-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, NgxDatatableModule, TranslateModule, HighlightjsWrapperComponent],
+  imports: [FormsModule, ReactiveFormsModule, NgxDatatableModule, TranslateDirective, TranslatePipe, HighlightjsWrapperComponent],
 })
 export class GameTeleSelectorModalComponent extends SearchSelectorModalComponent<GameTele> {
   protected entityIdField = GAME_TELE_ID;

--- a/libs/shared/selectors/src/selectors/gameobject-selector/gameobject-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/gameobject-selector/gameobject-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { GAMEOBJECT_TEMPLATE_ID, GameobjectTemplate } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { GameobjectSearchService } from '../../search/gameobject-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-gameobject-selector-modal',
   templateUrl: './gameobject-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class GameobjectSelectorModalComponent extends SearchSelectorModalComponent<GameobjectTemplate> {
   protected entityIdField = GAMEOBJECT_TEMPLATE_ID;

--- a/libs/shared/selectors/src/selectors/holiday-selector/holiday-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/holiday-selector/holiday-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { Holiday, HOLIDAY_ID } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { HolidaySearchService } from '../../search/holiday-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-holiday-selector-modal',
   templateUrl: './holiday-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class HolidaySelectorModalComponent extends SearchSelectorModalComponent<Holiday> {
   protected entityIdField = HOLIDAY_ID;

--- a/libs/shared/selectors/src/selectors/item-enchantment-selector/item-enchantment-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/item-enchantment-selector/item-enchantment-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { ITEM_ENCHANTMENT_ID, ItemEnchantment } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { ItemEnchantmentSearchService } from '../../search/item-enchantment-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-item-enchantment-selector-modal',
   templateUrl: './item-enchantment-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class ItemEnchantmentSelectorModalComponent extends SearchSelectorModalComponent<ItemEnchantment> {
   protected entityIdField = ITEM_ENCHANTMENT_ID;

--- a/libs/shared/selectors/src/selectors/item-extended-cost-selector/item-extended-cost-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/item-extended-cost-selector/item-extended-cost-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { ITEM_EXTENDED_COST_ID, ItemExtendedCost } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { ItemExtendedCostSearchService } from '../../search/item-extended-cost-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,15 @@ import { HighlightjsWrapperComponent, IconComponent } from '@keira/shared/base-e
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-item-extended-cost-selector-modal',
   templateUrl: './item-extended-cost-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule, IconComponent],
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    HighlightjsWrapperComponent,
+    NgxDatatableModule,
+    TranslateDirective,
+    TranslatePipe,
+    IconComponent,
+  ],
 })
 export class ItemExtendedCostSelectorModalComponent extends SearchSelectorModalComponent<ItemExtendedCost> {
   protected entityIdField = ITEM_EXTENDED_COST_ID;

--- a/libs/shared/selectors/src/selectors/item-limit-category-selector/item-limit-category-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/item-limit-category-selector/item-limit-category-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { ITEM_LIMIT_CATEGORY_ID, ItemLimitCategory } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { ItemLimitCategorySearchService } from '../../search/item-limit-category-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-item-limit-category-selector-modal',
   templateUrl: './item-limit-category-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class ItemLimitCategorySelectorModalComponent extends SearchSelectorModalComponent<ItemLimitCategory> {
   protected entityIdField = ITEM_LIMIT_CATEGORY_ID;

--- a/libs/shared/selectors/src/selectors/item-selector/item-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/item-selector/item-selector-modal.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { ITEM_TEMPLATE_ID, ItemTemplate } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { ItemSearchService } from '../../search/item-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -12,7 +12,15 @@ import { HighlightjsWrapperComponent, IconComponent } from '@keira/shared/base-e
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-item-selector-modal',
   templateUrl: './item-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, IconComponent, TranslateModule],
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    HighlightjsWrapperComponent,
+    NgxDatatableModule,
+    IconComponent,
+    TranslateDirective,
+    TranslatePipe,
+  ],
 })
 export class ItemSelectorModalComponent extends SearchSelectorModalComponent<ItemTemplate> {
   protected entityIdField = ITEM_TEMPLATE_ID;

--- a/libs/shared/selectors/src/selectors/language-selector/language-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/language-selector/language-selector-modal.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { LANGUAGE_ID, Language } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { LanguageSearchService } from '../../search/language-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -12,7 +12,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-language-selector-modal',
   templateUrl: './language-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class LanguageSelectorModalComponent extends SearchSelectorModalComponent<Language> {
   protected entityIdField = LANGUAGE_ID;

--- a/libs/shared/selectors/src/selectors/map-selector/map-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/map-selector/map-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { Map, MAP_ID } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { MapSearchService } from '../../search/map-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-map-selector-modal',
   templateUrl: './map-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class MapSelectorModalComponent extends SearchSelectorModalComponent<Map> {
   protected entityIdField = MAP_ID;

--- a/libs/shared/selectors/src/selectors/npc-text-selector/npc-text-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/npc-text-selector/npc-text-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { NPC_TEXT_ID, NpcText } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { NpcTextSearchService } from '../../search/npc-text-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-npc-text-selector-modal',
   templateUrl: './npc-text-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class NpcTextSelectorModalComponent extends SearchSelectorModalComponent<NpcText> {
   protected entityIdField = NPC_TEXT_ID;

--- a/libs/shared/selectors/src/selectors/quest-selector/quest-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/quest-selector/quest-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { QUEST_TEMPLATE_ID, QuestTemplate } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { QuestSearchService } from '../../search/quest-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-quest-selector-modal',
   templateUrl: './quest-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class QuestSelectorModalComponent extends SearchSelectorModalComponent<QuestTemplate> {
   protected entityIdField = QUEST_TEMPLATE_ID;

--- a/libs/shared/selectors/src/selectors/single-value-selector/single-value-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/single-value-selector/single-value-selector-modal.component.ts
@@ -4,7 +4,7 @@ import { BaseSelectorModalComponent } from '../base-selector/base-selector-modal
 import { DTCFG } from '@keira/shared/config';
 import { Option } from '@keira/shared/constants';
 import { SingleValueModalConfig } from './single-value-selector.model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 
 @Component({
@@ -12,7 +12,7 @@ import { NgxDatatableModule } from '@siemens/ngx-datatable';
   selector: 'keira-single-value-selector-modal',
   templateUrl: './single-value-selector-modal.component.html',
   styleUrls: ['./single-value-selector-modal.component.scss'],
-  imports: [NgxDatatableModule, TranslateModule],
+  imports: [NgxDatatableModule, TranslateDirective],
 })
 export class SingleValueSelectorModalComponent extends BaseSelectorModalComponent<SingleValueModalConfig> implements OnInit {
   readonly DTCFG = DTCFG;

--- a/libs/shared/selectors/src/selectors/skill-selector/skill-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/skill-selector/skill-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { Skill, SKILL_ID } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { SkillSearchService } from '../../search/skill-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-skill-selector-modal',
   templateUrl: './skill-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class SkillSelectorModalComponent extends SearchSelectorModalComponent<Skill> {
   protected entityIdField = SKILL_ID;

--- a/libs/shared/selectors/src/selectors/sound-entries-selector/sound-entries-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/sound-entries-selector/sound-entries-selector-modal.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { SOUND_ENTRIES_ID, SoundEntries } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
 
@@ -12,7 +12,7 @@ import { SoundEntriesSearchService } from '../../search/sound-entries-search.ser
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-sound-entries-selector-modal',
   templateUrl: './sound-entries-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule],
+  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateDirective, TranslatePipe],
 })
 export class SoundEntriesSelectorModalComponent extends SearchSelectorModalComponent<SoundEntries> {
   protected entityIdField = SOUND_ENTRIES_ID;

--- a/libs/shared/selectors/src/selectors/spell-selector/spell-selector-modal.component.ts
+++ b/libs/shared/selectors/src/selectors/spell-selector/spell-selector-modal.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { Spell, SPELL_ID } from '@keira/shared/acore-world-model';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { SpellSearchService } from '../../search/spell-search.service';
 import { SearchSelectorModalComponent } from '../base-selector/search-selector-modal.component';
@@ -13,7 +13,15 @@ import { HighlightjsWrapperComponent, IconComponent } from '@keira/shared/base-e
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-spell-selector-modal',
   templateUrl: './spell-selector-modal.component.html',
-  imports: [FormsModule, ReactiveFormsModule, HighlightjsWrapperComponent, NgxDatatableModule, TranslateModule, IconComponent],
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    HighlightjsWrapperComponent,
+    NgxDatatableModule,
+    TranslateDirective,
+    TranslatePipe,
+    IconComponent,
+  ],
 })
 export class SpellSelectorModalComponent extends SearchSelectorModalComponent<Spell> {
   protected entityIdField = SPELL_ID;

--- a/libs/shared/switch-language/src/switch-language.component.ts
+++ b/libs/shared/switch-language/src/switch-language.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { SwitchLanguageService } from './switch-language.service';
 
 @Component({
@@ -8,7 +8,7 @@ import { SwitchLanguageService } from './switch-language.service';
   selector: 'keira-switch-language',
   templateUrl: './switch-language.component.html',
   styleUrls: ['./switch-language.component.scss'],
-  imports: [FormsModule, TranslateModule],
+  imports: [FormsModule, TranslatePipe],
 })
 export class SwitchLanguageComponent {
   readonly longVersion = input(true);

--- a/libs/shared/test-utils/src/lib/translate-module.ts
+++ b/libs/shared/test-utils/src/lib/translate-module.ts
@@ -1,8 +1,9 @@
 import { NgModule } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
+import { provideTranslateService, TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 
 @NgModule({
-  imports: [TranslateModule.forRoot()],
-  exports: [TranslateModule],
+  imports: [TranslateDirective, TranslatePipe],
+  exports: [TranslateDirective, TranslatePipe],
+  providers: [provideTranslateService()],
 })
 export class TranslateTestingModule {}


### PR DESCRIPTION
Importing a whole NgModule into a standalone component pulls in everything it exports, whether the template uses it or not. This swaps every `TranslateModule` import for the declarables the template actually needs.

I worked out what each component needs by parsing its `templateUrl` and looking for `| translate` (pipe) vs `[translate]` (directive):

| needs | components |
| --- | --- |
| `TranslateDirective` + `TranslatePipe` | 92 |
| `TranslateDirective` only | 15 |
| `TranslatePipe` only | 14 |

Two things beyond the mechanical swap:

`TranslateTestingModule` was on `TranslateModule.forRoot()` with `exports: [TranslateModule]`, so it's still a whole-module import. It now uses `provideTranslateService()` and exports the two declarables, which matches what `apps/keira/src/main.ts` already does for the real app. It's consumed by 131 spec files.

`CommonModule` only appeared once, in the `TestModule` in `base-selector-btn.component.spec.ts`. That module has no `declarations` and nothing in it used a `CommonModule` declarable, so it's just removed rather than swapped.

## Checks

All run with `--skip-nx-cache`:

- `nx build keira` passes, and there are no `NG8113` unused-import diagnostics in the output. AOT template checking would have failed on any component where the wrong declarable got picked.
- `nx run-many -t test --all`: 30 projects, all green.
- `nx run-many -t lint --all`: 35 projects, clean.
- `nx format:check`: clean.
