### PR TITLE
refactor: import standalone ngx-bootstrap declarables instead of modules

### DIFF
--- a/apps/keira/src/app/app.component.spec.ts
+++ b/apps/keira/src/app/app.component.spec.ts
@@ -15,7 +15,7 @@ import packageInfo from '../../../../package.json';
 
 import { AppComponent } from './app.component';
 
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { BsDropdownDirective, BsDropdownMenuDirective, BsDropdownToggleDirective } from 'ngx-bootstrap/dropdown';
 import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config';
 import { MainWindowComponent } from '@keira/main/main-window';
 import { ConnectionWindowComponent } from '@keira/main/connection-window';
@@ -28,7 +28,9 @@ describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        BsDropdownModule,
+        BsDropdownDirective,
+        BsDropdownToggleDirective,
+        BsDropdownMenuDirective,
         FormsModule,
         ReactiveFormsModule,
         RouterTestingModule,

--- a/apps/keira/src/main.ts
+++ b/apps/keira/src/main.ts
@@ -8,10 +8,6 @@ import { provideRouter, withHashLocation } from '@angular/router';
 import { KEIRA_APP_CONFIG_TOKEN, highlightOptions, toastrConfig, uiSwitchConfig } from '@keira/shared/config';
 import { provideTranslateService } from '@ngx-translate/core';
 import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { HIGHLIGHT_OPTIONS } from 'ngx-highlightjs';
 import { ToastrModule } from 'ngx-toastr';
 import { UiSwitchModule } from 'ngx-ui-switch';
@@ -33,10 +29,6 @@ bootstrapApplication(AppComponent, {
       ReactiveFormsModule,
       FormsModule,
       /* External Libraries */
-      BsDropdownModule,
-      ModalModule,
-      TabsModule,
-      TooltipModule,
       ToastrModule.forRoot(toastrConfig),
       UiSwitchModule.forRoot(uiSwitchConfig),
     ),

--- a/libs/features/conditions/src/edit-conditions/conditions.component.ts
+++ b/libs/features/conditions/src/edit-conditions/conditions.component.ts
@@ -23,7 +23,7 @@ import { QueryOutputComponent } from '@keira/shared/base-editor-components';
 import { FlagsSelectorBtnComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { getEnumKeys } from '@keira/shared/utils';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ConditionsHandlerService } from '../conditions-handler.service';
 import {
   CONDITION_TARGET_TOOLTIPS,
@@ -46,7 +46,7 @@ import { ConditionsService } from './conditions.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     FlagsSelectorBtnComponent,
     SingleValueSelectorBtnComponent,
   ],

--- a/libs/features/conditions/src/edit-conditions/conditions.integration.spec.ts
+++ b/libs/features/conditions/src/edit-conditions/conditions.integration.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Conditions } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -59,7 +59,7 @@ describe('Conditions integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, ConditionsComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, ConditionsComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/conditions/src/select-conditions/select-conditions.integration.spec.ts
+++ b/libs/features/conditions/src/select-conditions/select-conditions.integration.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { ConditionsSearchService } from '@keira/shared/selectors';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { ConditionsHandlerService } from '../conditions-handler.service';
@@ -45,7 +45,7 @@ class SelectConditionsComponentPage extends PageObject<SelectConditionsComponent
 describe('SelectConditions integration tests', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectConditionsComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectConditionsComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-default-trainer/creature-default-trainer.component.ts
+++ b/libs/features/creature/src/creature-default-trainer/creature-default-trainer.component.ts
@@ -4,7 +4,7 @@ import { CreatureDefaultTrainer } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureDefaultTrainerService } from './creature-default-trainer.service';
 
@@ -12,7 +12,7 @@ import { CreatureDefaultTrainerService } from './creature-default-trainer.servic
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-creature-default-trainer',
   templateUrl: './creature-default-trainer.component.html',
-  imports: [TopBarComponent, TranslateDirective, TranslatePipe, QueryOutputComponent, FormsModule, ReactiveFormsModule, TooltipModule],
+  imports: [TopBarComponent, TranslateDirective, TranslatePipe, QueryOutputComponent, FormsModule, ReactiveFormsModule, TooltipDirective],
 })
 export class CreatureDefaultTrainerComponent extends SingleRowEditorComponent<CreatureDefaultTrainer> {
   protected override readonly editorService = inject(CreatureDefaultTrainerService);

--- a/libs/features/creature/src/creature-default-trainer/creature-default-trainer.integration.spec.ts
+++ b/libs/features/creature/src/creature-default-trainer/creature-default-trainer.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CreatureDefaultTrainer } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -28,7 +28,7 @@ describe('CreatureDefaultTrainer integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureDefaultTrainerComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureDefaultTrainerComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-equip-template/creature-equip-template.component.ts
+++ b/libs/features/creature/src/creature-equip-template/creature-equip-template.component.ts
@@ -7,7 +7,7 @@ import { ItemSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureEquipTemplateService } from './creature-equip-template.service';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,7 +23,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
     ReactiveFormsModule,
     IconComponent,
     ItemSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
   ],
 })
 export class CreatureEquipTemplateComponent extends SingleRowEditorComponent<CreatureEquipTemplate> {

--- a/libs/features/creature/src/creature-equip-template/creature-equip-template.integration.spec.ts
+++ b/libs/features/creature/src/creature-equip-template/creature-equip-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { CreatureEquipTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -28,7 +28,7 @@ describe('CreatureEquipTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureEquipTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureEquipTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-formations/creature-formations.component.ts
+++ b/libs/features/creature/src/creature-formations/creature-formations.component.ts
@@ -5,7 +5,6 @@ import { MultiRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureFormationsService } from './creature-formations.service';
 
@@ -20,7 +19,6 @@ import { CreatureFormationsService } from './creature-formations.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
     EditorButtonsComponent,
     NgxDatatableModule,
   ],

--- a/libs/features/creature/src/creature-formations/creature-formations.integration.spec.ts
+++ b/libs/features/creature/src/creature-formations/creature-formations.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CreatureFormation } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -30,7 +30,7 @@ describe('CreatureFormations integration tests', () => {
     TestBed.configureTestingModule({
       imports: [
         ToastrModule.forRoot(),
-        ModalModule,
+        ModalDirective,
         CreatureFormationsComponent, // This should typically be in declarations, but as per your instruction, it's left unchanged
         RouterTestingModule,
         TranslateTestingModule,

--- a/libs/features/creature/src/creature-loot-template/creature-loot-template.integration.spec.ts
+++ b/libs/features/creature/src/creature-loot-template/creature-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CreatureLootTemplate } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -30,7 +30,7 @@ describe('CreatureLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-onkill-reputation/creature-onkill-reputation.component.ts
+++ b/libs/features/creature/src/creature-onkill-reputation/creature-onkill-reputation.component.ts
@@ -5,7 +5,7 @@ import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { BooleanOptionSelectorComponent, FactionSelectorBtnComponent, GenericOptionSelectorComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureOnkillReputationService } from './creature-onkill-reputation.service';
 
@@ -22,7 +22,7 @@ import { CreatureOnkillReputationService } from './creature-onkill-reputation.se
     FormsModule,
     ReactiveFormsModule,
     FactionSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     BooleanOptionSelectorComponent,
     GenericOptionSelectorComponent,
   ],

--- a/libs/features/creature/src/creature-onkill-reputation/creature-onkill-reputation.integration.spec.ts
+++ b/libs/features/creature/src/creature-onkill-reputation/creature-onkill-reputation.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CreatureOnkillReputation } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteQueryService, SqliteService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -30,7 +30,7 @@ describe('CreatureOnkillReputation integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureOnkillReputationComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureOnkillReputationComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-questitem/creature-questitem.integration.spec.ts
+++ b/libs/features/creature/src/creature-questitem/creature-questitem.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { CreatureQuestitem } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -29,7 +29,7 @@ describe('CreatureQuestitem integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureQuestitemComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureQuestitemComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-spawn-addon/creature-spawn-addon.component.ts
+++ b/libs/features/creature/src/creature-spawn-addon/creature-spawn-addon.component.ts
@@ -6,7 +6,7 @@ import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureSpawnAddonService } from './creature-spawn-addon.service';
 
@@ -22,7 +22,7 @@ import { CreatureSpawnAddonService } from './creature-spawn-addon.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     NgxDatatableModule,
     GenericOptionSelectorComponent,
   ],

--- a/libs/features/creature/src/creature-spawn-addon/creature-spawn-addon.integration.spec.ts
+++ b/libs/features/creature/src/creature-spawn-addon/creature-spawn-addon.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CreatureSpawnAddon } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -29,7 +29,7 @@ describe('CreatureSpawnAddon integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureSpawnAddonComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureSpawnAddonComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-spawn/creature-spawn.integration.spec.ts
+++ b/libs/features/creature/src/creature-spawn/creature-spawn.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CreatureSpawn } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -29,7 +29,7 @@ describe('CreatureSpawn integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureSpawnComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureSpawnComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-template-addon/creature-template-addon.component.ts
+++ b/libs/features/creature/src/creature-template-addon/creature-template-addon.component.ts
@@ -11,7 +11,7 @@ import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTemplateAddonService } from './creature-template-addon.service';
 
@@ -27,7 +27,7 @@ import { CreatureTemplateAddonService } from './creature-template-addon.service'
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     SingleValueSelectorBtnComponent,
   ],
 })

--- a/libs/features/creature/src/creature-template-addon/creature-template-addon.integration.spec.ts
+++ b/libs/features/creature/src/creature-template-addon/creature-template-addon.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { CreatureTemplateAddon } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -34,7 +34,7 @@ describe('CreatureTemplateAddon integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureTemplateAddonComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureTemplateAddonComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-template-model/creature-template-model.component.ts
+++ b/libs/features/creature/src/creature-template-model/creature-template-model.component.ts
@@ -6,7 +6,6 @@ import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@
 import { Model3DViewerComponent, VIEWER_TYPE } from '@keira/shared/model-3d-viewer';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTemplateModelService } from './creature-template-model.service';
 
@@ -22,7 +21,6 @@ import { CreatureTemplateModelService } from './creature-template-model.service'
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
     NgxDatatableModule,
     EditorButtonsComponent,
     Model3DViewerComponent,

--- a/libs/features/creature/src/creature-template-model/creature-template-model.integration.spec.ts
+++ b/libs/features/creature/src/creature-template-model/creature-template-model.integration.spec.ts
@@ -10,7 +10,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -28,7 +28,7 @@ describe('CreatureTemplateModel integration tests', () => {
 
   function setup(creatingNew: boolean) {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureTemplateModelComponent, TranslateTestingModule, ReactiveFormsModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureTemplateModelComponent, TranslateTestingModule, ReactiveFormsModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-template-movement/creature-template-movement.component.ts
+++ b/libs/features/creature/src/creature-template-movement/creature-template-movement.component.ts
@@ -4,7 +4,7 @@ import { CREATURE_TEMPLATE_MOVEMENT_TABLE, CreatureTemplateMovement } from '@kei
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTemplateMovementService } from './creature-template-movement.service';
 
@@ -12,7 +12,7 @@ import { CreatureTemplateMovementService } from './creature-template-movement.se
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-creature-template-movement',
   templateUrl: './creature-template-movement.component.html',
-  imports: [TopBarComponent, TranslateDirective, TranslatePipe, QueryOutputComponent, FormsModule, ReactiveFormsModule, TooltipModule],
+  imports: [TopBarComponent, TranslateDirective, TranslatePipe, QueryOutputComponent, FormsModule, ReactiveFormsModule, TooltipDirective],
 })
 export class CreatureTemplateMovementComponent extends SingleRowEditorComponent<CreatureTemplateMovement> {
   protected override get docUrl(): string {

--- a/libs/features/creature/src/creature-template-movement/creature-template-movement.integration.spec.ts
+++ b/libs/features/creature/src/creature-template-movement/creature-template-movement.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CreatureTemplateMovement } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -35,7 +35,7 @@ describe('CreatureTemplateMovement integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureTemplateMovementComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureTemplateMovementComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.ts
+++ b/libs/features/creature/src/creature-template-resistance/creature-template-resistance.component.ts
@@ -10,7 +10,6 @@ import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTemplateResistanceService } from './creature-template-resistance.service';
 
@@ -28,7 +27,6 @@ import { CreatureTemplateResistanceService } from './creature-template-resistanc
     EditorButtonsComponent,
     NgxDatatableModule,
     GenericOptionSelectorComponent,
-    TooltipModule,
   ],
 })
 export class CreatureTemplateResistanceComponent extends MultiRowEditorComponent<CreatureTemplateResistance> {

--- a/libs/features/creature/src/creature-template-resistance/creature-template-resistance.integration.spec.ts
+++ b/libs/features/creature/src/creature-template-resistance/creature-template-resistance.integration.spec.ts
@@ -7,7 +7,7 @@ import { CreatureTemplateResistance } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { NgxSelectModule } from 'ngx-select-ex';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
@@ -24,7 +24,7 @@ describe('CreatureTemplateResistance integration tests', () => {
     TestBed.configureTestingModule({
       imports: [
         ToastrModule.forRoot(),
-        ModalModule,
+        ModalDirective,
         NgxSelectModule,
         CreatureTemplateResistanceComponent,
         TranslateTestingModule,

--- a/libs/features/creature/src/creature-template-spell/creature-template-spell.component.ts
+++ b/libs/features/creature/src/creature-template-spell/creature-template-spell.component.ts
@@ -8,7 +8,7 @@ import { SqliteQueryService } from '@keira/shared/db-layer';
 import { SpellSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTemplateSpellService } from './creature-template-spell.service';
 
@@ -23,7 +23,7 @@ import { CreatureTemplateSpellService } from './creature-template-spell.service'
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     EditorButtonsComponent,
     NgxDatatableModule,
     SpellSelectorBtnComponent,

--- a/libs/features/creature/src/creature-template-spell/creature-template-spell.integration.spec.ts
+++ b/libs/features/creature/src/creature-template-spell/creature-template-spell.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CreatureTemplateSpell } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -20,7 +20,7 @@ describe('CreatureTemplateSpell integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, CreatureTemplateSpellComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, CreatureTemplateSpellComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-template/creature-template.component.ts
+++ b/libs/features/creature/src/creature-template/creature-template.component.ts
@@ -31,7 +31,7 @@ import {
   SingleValueSelectorBtnComponent,
 } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTemplateService } from './creature-template.service';
 
@@ -46,7 +46,7 @@ import { CreatureTemplateService } from './creature-template.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     SingleValueSelectorBtnComponent,
     FactionSelectorBtnComponent,
     FlagsSelectorBtnComponent,

--- a/libs/features/creature/src/creature-template/creature-template.integration.spec.ts
+++ b/libs/features/creature/src/creature-template/creature-template.integration.spec.ts
@@ -9,7 +9,7 @@ import { CreatureTemplate } from '@keira/shared/acore-world-model';
 import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of, throwError } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -40,7 +40,7 @@ describe('CreatureTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/creature-text/creature-text.component.ts
+++ b/libs/features/creature/src/creature-text/creature-text.component.ts
@@ -6,7 +6,7 @@ import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@
 import { GenericOptionSelectorComponent, LanguageSelectorBtnComponent, SoundEntriesSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { CreatureTextService } from './creature-text.service';
 
@@ -18,7 +18,7 @@ import { CreatureTextService } from './creature-text.service';
     TopBarComponent,
     TranslateDirective,
     TranslatePipe,
-    TooltipModule,
+    TooltipDirective,
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/creature/src/creature-text/creature-text.integration.spec.ts
+++ b/libs/features/creature/src/creature-text/creature-text.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CreatureText } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -20,7 +20,7 @@ describe('CreatureText integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, CreatureTextComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, CreatureTextComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/npc-vendor/npc-vendor.component.ts
+++ b/libs/features/creature/src/npc-vendor/npc-vendor.component.ts
@@ -7,7 +7,7 @@ import { EditorButtonsComponent, IconComponent, QueryOutputComponent, TopBarComp
 import { ItemExtendedCostSelectorBtnComponent, ItemSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { CreatureHandlerService } from '../creature-handler.service';
 import { NpcVendorService } from './npc-vendor.service';
 
@@ -25,7 +25,7 @@ import { NpcVendorService } from './npc-vendor.service';
     ReactiveFormsModule,
     IconComponent,
     ItemSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     ItemExtendedCostSelectorBtnComponent,
     EditorButtonsComponent,
     NgxDatatableModule,

--- a/libs/features/creature/src/npc-vendor/npc-vendor.integration.spec.ts
+++ b/libs/features/creature/src/npc-vendor/npc-vendor.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { NpcVendor } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -29,7 +29,7 @@ describe('NpcVendor integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, NpcVendorComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, NpcVendorComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/pickpocketing-loot-template/pickpocketing-loot-template.integration.spec.ts
+++ b/libs/features/creature/src/pickpocketing-loot-template/pickpocketing-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { PickpocketingLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -30,7 +30,7 @@ describe('PickpocketingLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, PickpocketingLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, PickpocketingLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/sai-creature/sai-creature.component.integration.spec.ts
+++ b/libs/features/creature/src/sai-creature/sai-creature.component.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { SAI_TYPES, SmartScripts } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -31,7 +31,7 @@ describe('SaiCreatureComponent integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SaiCreatureComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SaiCreatureComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/sai-creature/sai-creature.component.ts
+++ b/libs/features/creature/src/sai-creature/sai-creature.component.ts
@@ -5,7 +5,7 @@ import { SaiEditorComponent, SaiTopBarComponent, TimedActionlistComponent } from
 import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { SaiCreatureHandlerService } from '../sai-creature-handler.service';
 import { SaiCreatureEditorService } from './sai-creature-editor.service';
 import { AsyncPipe } from '@angular/common';
@@ -22,7 +22,7 @@ import { AsyncPipe } from '@angular/common';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     FlagsSelectorBtnComponent,
     EditorButtonsComponent,
     NgxDatatableModule,

--- a/libs/features/creature/src/select-creature/select-creature.integration.spec.ts
+++ b/libs/features/creature/src/select-creature/select-creature.integration.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
@@ -31,7 +31,7 @@ describe('SelectCreature integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectCreatureComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectCreatureComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/creature/src/skinning-loot-template/skinning-loot-template.component.integration.spec.ts
+++ b/libs/features/creature/src/skinning-loot-template/skinning-loot-template.component.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { SkinningLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { CreatureHandlerService } from '../creature-handler.service';
@@ -30,7 +30,7 @@ describe('SkinningLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SkinningLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SkinningLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/game-tele/src/edit-game-tele/game-tele.integration.spec.ts
+++ b/libs/features/game-tele/src/edit-game-tele/game-tele.integration.spec.ts
@@ -5,7 +5,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { GameTele } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteQueryService, SqliteService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -38,7 +38,7 @@ describe('GameTele integration tests', () => {
   // TestBed Configuration
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, TranslateTestingModule],
       declarations: [],
       providers: [
         provideZonelessChangeDetection(),

--- a/libs/features/game-tele/src/select-game-tele/select-game-tele.integration.spec.ts
+++ b/libs/features/game-tele/src/select-game-tele/select-game-tele.integration.spec.ts
@@ -5,7 +5,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { SelectGameTeleComponent } from './select-game-tele.component';
@@ -45,7 +45,7 @@ describe('SelectConditions integration tests', () => {
    */
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, TranslateTestingModule],
       declarations: [],
       providers: [
         provideZonelessChangeDetection(),

--- a/libs/features/gameobject/src/gameobject-loot-template/gameobject-loot-template.component.spec.ts
+++ b/libs/features/gameobject/src/gameobject-loot-template/gameobject-loot-template.component.spec.ts
@@ -5,8 +5,8 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ModalDirective } from 'ngx-bootstrap/modal';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 import { of, throwError } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
@@ -26,8 +26,8 @@ describe('GameobjectTemplateComponent', () => {
       imports: [
         GameobjectLootTemplateComponent,
         RouterTestingModule,
-        ModalModule,
-        TooltipModule,
+        ModalDirective,
+        TooltipDirective,
         ToastrModule.forRoot(),
         TranslateTestingModule,
       ],

--- a/libs/features/gameobject/src/gameobject-loot-template/gameobject-loot-template.integration.spec.ts
+++ b/libs/features/gameobject/src/gameobject-loot-template/gameobject-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { GameobjectLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
@@ -31,7 +31,7 @@ describe('GameobjectLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, GameobjectLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, GameobjectLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/gameobject/src/gameobject-questitem/gameobject-questitem.integration.spec.ts
+++ b/libs/features/gameobject/src/gameobject-questitem/gameobject-questitem.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { GameobjectQuestitem } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
@@ -29,7 +29,7 @@ describe('GameobjectQuestitem integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, GameobjectQuestitemComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, GameobjectQuestitemComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/gameobject/src/gameobject-spawn-addon/gameobject-spawn-addon.component.ts
+++ b/libs/features/gameobject/src/gameobject-spawn-addon/gameobject-spawn-addon.component.ts
@@ -6,7 +6,7 @@ import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor
 import { SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
 import { GameobjectSpawnAddonService } from './gameobject-spawn-addon.service';
 
@@ -21,7 +21,7 @@ import { GameobjectSpawnAddonService } from './gameobject-spawn-addon.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     SingleValueSelectorBtnComponent,
     NgxDatatableModule,
   ],

--- a/libs/features/gameobject/src/gameobject-spawn-addon/gameobject-spawn-addon.integration.spec.ts
+++ b/libs/features/gameobject/src/gameobject-spawn-addon/gameobject-spawn-addon.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { GameobjectSpawnAddon } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
@@ -29,7 +29,7 @@ describe('GameobjectSpawnAddon integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, GameobjectSpawnAddonComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, GameobjectSpawnAddonComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/gameobject/src/gameobject-spawn/gameobject-spawn.integration.spec.ts
+++ b/libs/features/gameobject/src/gameobject-spawn/gameobject-spawn.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { GameobjectSpawn } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
@@ -29,7 +29,7 @@ describe('GameobjectSpawn integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, GameobjectSpawnComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, GameobjectSpawnComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/gameobject/src/gameobject-template-addon/gameobject-template-addon.component.ts
+++ b/libs/features/gameobject/src/gameobject-template-addon/gameobject-template-addon.component.ts
@@ -5,7 +5,7 @@ import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { FactionSelectorBtnComponent, FlagsSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
 import { GameobjectTemplateAddonService } from './gameobject-template-addon.service';
 
@@ -21,7 +21,7 @@ import { GameobjectTemplateAddonService } from './gameobject-template-addon.serv
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     FactionSelectorBtnComponent,
     FlagsSelectorBtnComponent,
   ],

--- a/libs/features/gameobject/src/gameobject-template-addon/gameobject-template-addon.integration.spec.ts
+++ b/libs/features/gameobject/src/gameobject-template-addon/gameobject-template-addon.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { GameobjectTemplateAddon } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
@@ -32,7 +32,7 @@ describe('GameobjectTemplateAddon integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, GameobjectTemplateAddonComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, GameobjectTemplateAddonComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/gameobject/src/gameobject-template/gameobject-template.component.spec.ts
+++ b/libs/features/gameobject/src/gameobject-template/gameobject-template.component.spec.ts
@@ -7,7 +7,7 @@ import { FieldDefinition } from '@keira/shared/constants';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
@@ -18,7 +18,7 @@ import { GameobjectTemplateService } from './gameobject-template.service';
 describe('GameobjectComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, ToastrModule.forRoot(), GameobjectTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ModalDirective, ToastrModule.forRoot(), GameobjectTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), GameobjectHandlerService, SaiGameobjectHandlerService],
     }).compileComponents();
   });

--- a/libs/features/gameobject/src/gameobject-template/gameobject-template.component.ts
+++ b/libs/features/gameobject/src/gameobject-template/gameobject-template.component.ts
@@ -7,7 +7,7 @@ import { FieldDefinition } from '@keira/shared/constants';
 import { Model3DViewerComponent, VIEWER_TYPE } from '@keira/shared/model-3d-viewer';
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
 import { GameobjectTemplateService } from './gameobject-template.service';
 
@@ -23,7 +23,7 @@ import { GameobjectTemplateService } from './gameobject-template.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     Model3DViewerComponent,
     GenericOptionSelectorComponent,
   ],

--- a/libs/features/gameobject/src/gameobject-template/gameobject-template.integration.spec.ts
+++ b/libs/features/gameobject/src/gameobject-template/gameobject-template.integration.spec.ts
@@ -11,7 +11,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -43,7 +43,7 @@ describe('GameobjectTemplate integration tests', () => {
     TestBed.configureTestingModule({
       imports: [
         ToastrModule.forRoot(),
-        ModalModule,
+        ModalDirective,
         GameobjectTemplateComponent,
         RouterTestingModule,
         TranslateTestingModule,

--- a/libs/features/gameobject/src/sai-gameobject/sai-gameobject.component.integration.spec.ts
+++ b/libs/features/gameobject/src/sai-gameobject/sai-gameobject.component.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { SAI_TYPES, SmartScripts } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { GameobjectHandlerService } from '../gameobject-handler.service';
@@ -31,7 +31,7 @@ describe('SaiGameobjectComponent integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SaiGameobjectComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SaiGameobjectComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/gameobject/src/sai-gameobject/sai-gameobject.component.ts
+++ b/libs/features/gameobject/src/sai-gameobject/sai-gameobject.component.ts
@@ -5,7 +5,7 @@ import { SaiEditorComponent, SaiTopBarComponent, TimedActionlistComponent } from
 import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { SaiGameobjectHandlerService } from '../sai-gameobject-handler.service';
 import { SaiGameobjectEditorService } from './sai-gameobject-editor.service';
 import { AsyncPipe } from '@angular/common';
@@ -22,7 +22,7 @@ import { AsyncPipe } from '@angular/common';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     FlagsSelectorBtnComponent,
     EditorButtonsComponent,
     NgxDatatableModule,

--- a/libs/features/gameobject/src/select-gameobject/select-gameobject.integration.spec.ts
+++ b/libs/features/gameobject/src/select-gameobject/select-gameobject.integration.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { GameobjectTemplate } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -24,7 +24,7 @@ describe('SelectGameobject integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectGameobjectComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectGameobjectComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/gossip/src/gossip-menu-option/gossip-menu-option.component.ts
+++ b/libs/features/gossip/src/gossip-menu-option/gossip-menu-option.component.ts
@@ -6,7 +6,7 @@ import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@
 import { GenericOptionSelectorComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { GossipHandlerService } from '../gossip-handler.service';
 import { GossipMenuOptionPreviewComponent } from '../gossip-menu-option-preview/gossip-menu-option-preview.component';
 import { GossipMenuOptionService } from './gossip-menu-option.service';
@@ -22,7 +22,7 @@ import { GossipMenuOptionService } from './gossip-menu-option.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     SingleValueSelectorBtnComponent,
     EditorButtonsComponent,
     NgxDatatableModule,

--- a/libs/features/gossip/src/gossip-menu-option/gossip-menu-option.integration.spec.ts
+++ b/libs/features/gossip/src/gossip-menu-option/gossip-menu-option.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { GossipMenuOption } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { GossipHandlerService } from '../gossip-handler.service';
@@ -28,7 +28,7 @@ describe('GossipMenu integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, GossipMenuOptionComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, GossipMenuOptionComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/gossip/src/gossip-menu/gossip-menu.component.ts
+++ b/libs/features/gossip/src/gossip-menu/gossip-menu.component.ts
@@ -8,7 +8,7 @@ import { MysqlQueryService } from '@keira/shared/db-layer';
 import { NpcTextSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { GossipHandlerService } from '../gossip-handler.service';
 import { GossipMenuService } from './gossip-menu.service';
 
@@ -25,7 +25,7 @@ import { GossipMenuService } from './gossip-menu.service';
     FormsModule,
     ReactiveFormsModule,
     NpcTextSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     EditorButtonsComponent,
     NgxDatatableModule,
     AsyncPipe,

--- a/libs/features/gossip/src/gossip-menu/gossip-menu.integration.spec.ts
+++ b/libs/features/gossip/src/gossip-menu/gossip-menu.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { GossipMenu } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { GossipHandlerService } from '../gossip-handler.service';
@@ -28,7 +28,7 @@ describe('GossipMenu integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, GossipMenuComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, GossipMenuComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/gossip/src/select-gossip/select-gossip.integration.spec.ts
+++ b/libs/features/gossip/src/select-gossip/select-gossip.integration.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { GossipMenu } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { GossipHandlerService } from '../gossip-handler.service';
@@ -23,7 +23,7 @@ describe('SelectGossip integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectGossipComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectGossipComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), GossipHandlerService],
     }).compileComponents();
   });

--- a/libs/features/item/src/disenchant-loot-template/disenchant-loot-template.integration.spec.ts
+++ b/libs/features/item/src/disenchant-loot-template/disenchant-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { DisenchantLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { ItemHandlerService } from '../item-handler.service';
@@ -29,7 +29,7 @@ describe('DisenchantLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, DisenchantLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, DisenchantLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/item/src/item-enchantment/item-enchantment-template.integration.spec.ts
+++ b/libs/features/item/src/item-enchantment/item-enchantment-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ItemEnchantmentTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { ItemHandlerService } from '../item-handler.service';
@@ -27,14 +27,7 @@ describe('ItemEnchantmentTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ToastrModule.forRoot(),
-        ModalModule,
-        ItemEnchantmentTemplateComponent,
-        RouterTestingModule,
-        ModalModule,
-        TranslateTestingModule,
-      ],
+      imports: [ToastrModule.forRoot(), ModalDirective, ItemEnchantmentTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), ItemHandlerService],
     }).compileComponents();
   });

--- a/libs/features/item/src/item-loot-template/item-loot-template.integration.spec.ts
+++ b/libs/features/item/src/item-loot-template/item-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ItemLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { ItemHandlerService } from '../item-handler.service';
@@ -28,7 +28,7 @@ describe('ItemLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, ItemLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, ItemLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/item/src/item-template/item-template.component.ts
+++ b/libs/features/item/src/item-template/item-template.component.ts
@@ -43,7 +43,7 @@ import {
 } from '@keira/shared/selectors';
 import { compareObjFn } from '@keira/shared/utils';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { debounceTime, distinctUntilChanged } from 'rxjs';
 import { ItemHandlerService } from '../item-handler.service';
 import { SPELL_TRIGGERS } from './item-constants';
@@ -62,7 +62,7 @@ import { ItemTemplateService } from './item-template.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     SingleValueSelectorBtnComponent,
     QuestSelectorBtnComponent,
     FlagsSelectorBtnComponent,

--- a/libs/features/item/src/item-template/item-template.integration.spec.ts
+++ b/libs/features/item/src/item-template/item-template.integration.spec.ts
@@ -10,7 +10,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService, SqliteQueryService, SqliteService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { tickAsync } from 'ngx-page-object-model';
 import { ToastrModule } from 'ngx-toastr';
 import { lastValueFrom, of } from 'rxjs';
@@ -59,7 +59,7 @@ describe('ItemTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, ItemTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, ItemTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/item/src/milling-loot-template/milling-loot-template.integration.spec.ts
+++ b/libs/features/item/src/milling-loot-template/milling-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { MillingLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { ItemHandlerService } from '../item-handler.service';
@@ -28,7 +28,7 @@ describe('MillingLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, MillingLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, MillingLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/item/src/prospecting-loot-template/prospecting-loot-template.integration.spec.ts
+++ b/libs/features/item/src/prospecting-loot-template/prospecting-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ProspectingLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { ItemHandlerService } from '../item-handler.service';
@@ -28,7 +28,7 @@ describe('ProspectingLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, ProspectingLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, ProspectingLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/item/src/select-item/select-item.integration.spec.ts
+++ b/libs/features/item/src/select-item/select-item.integration.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ItemTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { ItemHandlerService } from '../item-handler.service';
@@ -23,7 +23,7 @@ describe('SelectItem integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectItemComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectItemComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/other-loots/src/fishing-loot/fishing-loot-template.integration.spec.ts
+++ b/libs/features/other-loots/src/fishing-loot/fishing-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { FishingLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { FishingLootHandlerService } from './fishing-loot-handler.service';
@@ -28,7 +28,7 @@ describe('FishingLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, FishingLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, FishingLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/other-loots/src/fishing-loot/select-fishing-loot.integration.spec.ts
+++ b/libs/features/other-loots/src/fishing-loot/select-fishing-loot.integration.spec.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { FishingLootHandlerService } from './fishing-loot-handler.service';
@@ -22,7 +22,7 @@ describe('SelectFishingLoot integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectFishingLootComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectFishingLootComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), FishingLootHandlerService],
     }).compileComponents();
   });

--- a/libs/features/other-loots/src/mail-loot/mail-loot-template.integration.spec.ts
+++ b/libs/features/other-loots/src/mail-loot/mail-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { MailLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { MailLootHandlerService } from './mail-loot-handler.service';
@@ -28,7 +28,7 @@ describe('MailLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, MailLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, MailLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/other-loots/src/mail-loot/select-mail-loot.integration.spec.ts
+++ b/libs/features/other-loots/src/mail-loot/select-mail-loot.integration.spec.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { MailLootHandlerService } from './mail-loot-handler.service';
@@ -22,7 +22,7 @@ describe('SelectMailLoot integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectMailLootComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectMailLootComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), MailLootHandlerService],
     }).compileComponents();
   });

--- a/libs/features/other-loots/src/reference-loot/reference-loot-template.integration.spec.ts
+++ b/libs/features/other-loots/src/reference-loot/reference-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ReferenceLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { ReferenceLootHandlerService } from './reference-loot-handler.service';
@@ -28,7 +28,7 @@ describe('ReferenceLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, ReferenceLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, ReferenceLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/other-loots/src/reference-loot/select-reference-loot.integration.spec.ts
+++ b/libs/features/other-loots/src/reference-loot/select-reference-loot.integration.spec.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { ReferenceLootHandlerService } from './reference-loot-handler.service';
@@ -22,7 +22,7 @@ describe('SelectReferenceLoot integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectReferenceLootComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectReferenceLootComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), ReferenceLootHandlerService],
     }).compileComponents();
   });

--- a/libs/features/other-loots/src/spell-loot/select-spell-loot.integration.spec.ts
+++ b/libs/features/other-loots/src/spell-loot/select-spell-loot.integration.spec.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { SelectSpellLootComponent } from './select-spell-loot.component';
@@ -22,7 +22,7 @@ describe('SelectSpellLoot integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectSpellLootComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectSpellLootComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), SpellLootHandlerService],
     }).compileComponents();
   });

--- a/libs/features/other-loots/src/spell-loot/spell-loot-template.integration.spec.ts
+++ b/libs/features/other-loots/src/spell-loot/spell-loot-template.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService, SqliteService } from '@keira/shared/db-layer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { SpellLootTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { SpellLootHandlerService } from './spell-loot-handler.service';
@@ -28,7 +28,7 @@ describe('SpellLootTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SpellLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SpellLootTemplateComponent, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/quest/src/creature-questender/creature-questender.component.ts
+++ b/libs/features/quest/src/creature-questender/creature-questender.component.ts
@@ -7,7 +7,7 @@ import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@
 import { CreatureSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
 import { QuestPreviewService } from '../quest-preview/quest-preview.service';
@@ -26,7 +26,7 @@ import { CreatureQuestenderService } from './creature-questender.service';
     FormsModule,
     ReactiveFormsModule,
     CreatureSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     EditorButtonsComponent,
     NgxDatatableModule,
     QuestPreviewComponent,

--- a/libs/features/quest/src/creature-questender/creature-questender.integration.spec.ts
+++ b/libs/features/quest/src/creature-questender/creature-questender.integration.spec.ts
@@ -10,7 +10,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -28,7 +28,7 @@ describe('CreatureQuestender integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, CreatureQuestenderComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, CreatureQuestenderComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/quest/src/creature-queststarter/creature-queststarter.component.ts
+++ b/libs/features/quest/src/creature-queststarter/creature-queststarter.component.ts
@@ -7,7 +7,7 @@ import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@
 import { CreatureSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
 import { QuestPreviewService } from '../quest-preview/quest-preview.service';
@@ -26,7 +26,7 @@ import { CreatureQueststarterService } from './creature-queststarter.service';
     FormsModule,
     ReactiveFormsModule,
     CreatureSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     EditorButtonsComponent,
     NgxDatatableModule,
     QuestPreviewComponent,

--- a/libs/features/quest/src/creature-queststarter/creature-queststarter.integration.spec.ts
+++ b/libs/features/quest/src/creature-queststarter/creature-queststarter.integration.spec.ts
@@ -10,7 +10,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -28,7 +28,7 @@ describe('CreatureQueststarter integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, CreatureQueststarterComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, CreatureQueststarterComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/quest/src/gameobject-questender/gameobject-questender.component.ts
+++ b/libs/features/quest/src/gameobject-questender/gameobject-questender.component.ts
@@ -7,7 +7,7 @@ import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@
 import { GameobjectSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
 import { QuestPreviewService } from '../quest-preview/quest-preview.service';
@@ -26,7 +26,7 @@ import { GameobjectQuestenderService } from './gameobject-questender.service';
     FormsModule,
     ReactiveFormsModule,
     GameobjectSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     EditorButtonsComponent,
     NgxDatatableModule,
     QuestPreviewComponent,

--- a/libs/features/quest/src/gameobject-questender/gameobject-questender.integration.spec.ts
+++ b/libs/features/quest/src/gameobject-questender/gameobject-questender.integration.spec.ts
@@ -10,7 +10,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -28,7 +28,7 @@ describe('GameobjectQuestender integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, GameobjectQuestenderComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, GameobjectQuestenderComponent, TranslateTestingModule],
       providers: [
         { provide: Model3DViewerService, useValue: { generateModels: () => new Promise((resolve) => resolve({ destroy: () => {} })) } },
         provideZonelessChangeDetection(),

--- a/libs/features/quest/src/gameobject-queststarter/gameobject-queststarter.component.ts
+++ b/libs/features/quest/src/gameobject-queststarter/gameobject-queststarter.component.ts
@@ -7,7 +7,7 @@ import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@
 import { GameobjectSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
 import { QuestPreviewService } from '../quest-preview/quest-preview.service';
@@ -26,7 +26,7 @@ import { GameobjectQueststarterService } from './gameobject-queststarter.service
     FormsModule,
     ReactiveFormsModule,
     GameobjectSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     EditorButtonsComponent,
     NgxDatatableModule,
     QuestPreviewComponent,

--- a/libs/features/quest/src/gameobject-queststarter/gameobject-queststarter.integration.spec.ts
+++ b/libs/features/quest/src/gameobject-queststarter/gameobject-queststarter.integration.spec.ts
@@ -10,7 +10,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -36,7 +36,7 @@ describe('GameobjectQueststarter integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, GameobjectQueststarterComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, GameobjectQueststarterComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/quest/src/quest-offer-reward/quest-offer-reward.component.ts
+++ b/libs/features/quest/src/quest-offer-reward/quest-offer-reward.component.ts
@@ -5,7 +5,7 @@ import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
 import { QuestPreviewService } from '../quest-preview/quest-preview.service';
@@ -23,7 +23,7 @@ import { QuestOfferRewardService } from './quest-offer-reward.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     SingleValueSelectorBtnComponent,
     QuestPreviewComponent,
   ],

--- a/libs/features/quest/src/quest-offer-reward/quest-offer-reward.integration.spec.ts
+++ b/libs/features/quest/src/quest-offer-reward/quest-offer-reward.integration.spec.ts
@@ -8,7 +8,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { tickAsync } from 'ngx-page-object-model';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
@@ -45,7 +45,7 @@ describe('QuestOfferReward integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, QuestOfferRewardComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, QuestOfferRewardComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/quest/src/quest-preview/quest-preview.component.ts
+++ b/libs/features/quest/src/quest-preview/quest-preview.component.ts
@@ -8,7 +8,7 @@ import { RacesTextKey, RacesTextValue } from '@keira/shared/constants';
 import { MapPoint, MapViewerComponent } from '@keira/shared/map-viewer';
 import { Model3DViewerComponent, VIEWER_TYPE } from '@keira/shared/model-3d-viewer';
 import { PreviewHelperService } from '@keira/shared/preview';
-import { CollapseModule } from 'ngx-bootstrap/collapse';
+import { CollapseDirective } from 'ngx-bootstrap/collapse';
 import { Quest } from './quest-preview.model';
 import { QuestPreviewService } from './quest-preview.service';
 import { from, Observable, of } from 'rxjs';
@@ -19,7 +19,7 @@ export const QUEST_PREVIEW_DEBOUNCE_TIME = 300;
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-quest-preview',
   templateUrl: './quest-preview.component.html',
-  imports: [IconComponent, CollapseModule, AsyncPipe, QuestObjectivesComponent, Model3DViewerComponent, MapViewerComponent],
+  imports: [IconComponent, CollapseDirective, AsyncPipe, QuestObjectivesComponent, Model3DViewerComponent, MapViewerComponent],
 })
 export class QuestPreviewComponent implements OnInit {
   private readonly changeDetectorRef = inject(ChangeDetectorRef);

--- a/libs/features/quest/src/quest-request-items/quest-request-items.component.ts
+++ b/libs/features/quest/src/quest-request-items/quest-request-items.component.ts
@@ -5,7 +5,7 @@ import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
 import { QuestPreviewService } from '../quest-preview/quest-preview.service';
@@ -23,7 +23,7 @@ import { QuestRequestItemsService } from './quest-request-items.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     SingleValueSelectorBtnComponent,
     QuestPreviewComponent,
   ],

--- a/libs/features/quest/src/quest-request-items/quest-request-items.integration.spec.ts
+++ b/libs/features/quest/src/quest-request-items/quest-request-items.integration.spec.ts
@@ -8,7 +8,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { tickAsync } from 'ngx-page-object-model';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
@@ -32,7 +32,7 @@ describe('QuestRequestItems integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, QuestRequestItemsComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, QuestRequestItemsComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/quest/src/quest-template-addon/quest-template-addon.component.ts
+++ b/libs/features/quest/src/quest-template-addon/quest-template-addon.component.ts
@@ -11,7 +11,7 @@ import {
   SpellSelectorBtnComponent,
 } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
 import { QuestPreviewService } from '../quest-preview/quest-preview.service';
@@ -29,7 +29,7 @@ import { QuestTemplateAddonService } from './quest-template-addon.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     QuestSelectorBtnComponent,
     FlagsSelectorBtnComponent,
     SpellSelectorBtnComponent,

--- a/libs/features/quest/src/quest-template-addon/quest-template-addon.integration.spec.ts
+++ b/libs/features/quest/src/quest-template-addon/quest-template-addon.integration.spec.ts
@@ -7,7 +7,7 @@ import { QuestTemplateAddon } from '@keira/shared/acore-world-model';
 import { MysqlQueryService, SqliteQueryService, SqliteService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { tickAsync } from 'ngx-page-object-model';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
@@ -55,7 +55,7 @@ describe('QuestTemplateAddon integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, QuestTemplateAddonComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, QuestTemplateAddonComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/quest/src/quest-template-locale/quest-template-locale.component.ts
+++ b/libs/features/quest/src/quest-template-locale/quest-template-locale.component.ts
@@ -6,7 +6,7 @@ import { EditorButtonsComponent, QueryOutputComponent, TopBarComponent } from '@
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
 import { QuestPreviewService } from '../quest-preview/quest-preview.service';
@@ -23,7 +23,7 @@ import { QuestTemplateLocaleService } from './quest-template-locale.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     QuestPreviewComponent,
     EditorButtonsComponent,
     NgxDatatableModule,

--- a/libs/features/quest/src/quest-template-locale/quest-template-locale.integration.spec.ts
+++ b/libs/features/quest/src/quest-template-locale/quest-template-locale.integration.spec.ts
@@ -7,7 +7,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -21,7 +21,7 @@ describe('QuestTemplateLocale integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, QuestTemplateLocaleComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, QuestTemplateLocaleComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/quest/src/quest-template/quest-template.component.ts
+++ b/libs/features/quest/src/quest-template/quest-template.component.ts
@@ -12,7 +12,7 @@ import {
   SpellSelectorBtnComponent,
 } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { QuestHandlerService } from '../quest-handler.service';
 import { QuestPreviewComponent } from '../quest-preview/quest-preview.component';
 import { QuestPreviewService } from '../quest-preview/quest-preview.service';
@@ -30,7 +30,7 @@ import { QuestTemplateService } from './quest-template.service';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     SingleValueSelectorBtnComponent,
     IconComponent,
     ItemSelectorBtnComponent,

--- a/libs/features/quest/src/quest-template/quest-template.integration.spec.ts
+++ b/libs/features/quest/src/quest-template/quest-template.integration.spec.ts
@@ -8,7 +8,7 @@ import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config'
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { Model3DViewerService } from '@keira/shared/model-3d-viewer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -48,7 +48,7 @@ describe('QuestTemplate integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, QuestTemplateComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, QuestTemplateComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/quest/src/select-quest/select-quest.integration.spec.ts
+++ b/libs/features/quest/src/select-quest/select-quest.integration.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { QuestTemplate } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { QuestHandlerService } from '../quest-handler.service';
@@ -22,7 +22,7 @@ describe('SelectQuest integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), QuestHandlerService],
     }).compileComponents();
   });

--- a/libs/features/smart-scripts/src/sai-search-entity/sai-search-entity.component.spec.ts
+++ b/libs/features/smart-scripts/src/sai-search-entity/sai-search-entity.component.spec.ts
@@ -5,7 +5,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SaiHandlerService } from '@keira/shared/sai-editor';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { SaiSearchEntityComponent } from './sai-search-entity.component';
 
 class SaiSearchEntityComponentPage extends PageObject<SaiSearchEntityComponent> {
@@ -41,7 +41,7 @@ class SaiSearchEntityComponentPage extends PageObject<SaiSearchEntityComponent> 
 describe('SaiSearchEntityComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, SaiSearchEntityComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ModalDirective, SaiSearchEntityComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/features/smart-scripts/src/sai-search-existing/sai-search-existing.integration.spec.ts
+++ b/libs/features/smart-scripts/src/sai-search-existing/sai-search-existing.integration.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { SmartScripts } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { SaiSearchExistingComponent } from './sai-search-existing.component';
@@ -30,7 +30,7 @@ class SaiSearchExistingComponentPage extends PageObject<SaiSearchExistingCompone
 describe('SaiSearchExisting integration tests', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SaiSearchExistingComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SaiSearchExistingComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/features/spell/src/select-spell/select-spell.component.integration.spec.ts
+++ b/libs/features/spell/src/select-spell/select-spell.component.integration.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { SPELL_DBC_ID, SPELL_DBC_NAME, SpellDbc } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { SpellHandlerService } from '../spell-handler.service';
@@ -27,7 +27,7 @@ describe('SelectSpell integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/spell/src/spell-dbc/base/spell-dbc-base.component.spec.ts
+++ b/libs/features/spell/src/spell-dbc/base/spell-dbc-base.component.spec.ts
@@ -6,8 +6,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { SpellDbc } from '@keira/shared/acore-world-model';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ModelForm } from '@keira/shared/utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ModalDirective } from 'ngx-bootstrap/modal';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 import { SpellHandlerService } from '../../spell-handler.service';
 
@@ -80,9 +80,9 @@ describe('SpellDbcBaseComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        ModalModule,
+        ModalDirective,
         ToastrModule.forRoot(),
-        TooltipModule,
+        TooltipDirective,
         RouterTestingModule,
         TranslateTestingModule,
         TestHostComponent,

--- a/libs/features/spell/src/spell-dbc/base/spell-dbc-base.component.ts
+++ b/libs/features/spell/src/spell-dbc/base/spell-dbc-base.component.ts
@@ -15,7 +15,7 @@ import {
 import { FlagsSelectorBtnComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { ModelForm } from '@keira/shared/utils';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -26,7 +26,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
     ReactiveFormsModule,
     TranslateDirective,
     TranslatePipe,
-    TooltipModule,
+    TooltipDirective,
     SingleValueSelectorBtnComponent,
     FlagsSelectorBtnComponent,
   ],

--- a/libs/features/spell/src/spell-dbc/effects/spell-dbc-effects.component.spec.ts
+++ b/libs/features/spell/src/spell-dbc/effects/spell-dbc-effects.component.spec.ts
@@ -6,8 +6,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ModelForm } from '@keira/shared/utils';
 import { SpellDbc } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ModalDirective } from 'ngx-bootstrap/modal';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 import { SpellHandlerService } from '../../spell-handler.service';
 
@@ -42,9 +42,9 @@ describe('SpellDbcEffectsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        ModalModule,
+        ModalDirective,
         ToastrModule.forRoot(),
-        TooltipModule,
+        TooltipDirective,
         RouterTestingModule,
         TranslateTestingModule,
         TestHostComponent,

--- a/libs/features/spell/src/spell-dbc/effects/spell-dbc-effects.component.ts
+++ b/libs/features/spell/src/spell-dbc/effects/spell-dbc-effects.component.ts
@@ -4,8 +4,8 @@ import { SPELL_DBC_PROC_FLAGS, SPELL_DBC_TARGETS, SpellDbc } from '@keira/shared
 import { ModelForm } from '@keira/shared/utils';
 import { TranslatePipe } from '@ngx-translate/core';
 import { SpellDbcSpellEffectComponent } from './spell-dbc-spell-effect/spell-dbc-spell-effect.component';
-import { TabsModule } from 'ngx-bootstrap/tabs';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TabDirective, TabsetComponent } from 'ngx-bootstrap/tabs';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
 
 @Component({
@@ -16,8 +16,9 @@ import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
     FormsModule,
     ReactiveFormsModule,
     FlagsSelectorBtnComponent,
-    TooltipModule,
-    TabsModule,
+    TooltipDirective,
+    TabsetComponent,
+    TabDirective,
     SpellDbcSpellEffectComponent,
     TranslatePipe,
   ],

--- a/libs/features/spell/src/spell-dbc/effects/spell-dbc-spell-effect/spell-dbc-spell-effect.component.spec.ts
+++ b/libs/features/spell/src/spell-dbc/effects/spell-dbc-spell-effect/spell-dbc-spell-effect.component.spec.ts
@@ -6,8 +6,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ModelForm } from '@keira/shared/utils';
 import { SpellDbc } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ModalDirective } from 'ngx-bootstrap/modal';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 import { SpellHandlerService } from '../../../spell-handler.service';
 import { SpellDbcService } from '../../spell-dbc.service';
@@ -41,9 +41,9 @@ describe('SpellDbcSpellEffectComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        ModalModule,
+        ModalDirective,
         ToastrModule.forRoot(),
-        TooltipModule,
+        TooltipDirective,
         RouterTestingModule,
         TranslateTestingModule,
         TestHostComponent,

--- a/libs/features/spell/src/spell-dbc/effects/spell-dbc-spell-effect/spell-dbc-spell-effect.component.ts
+++ b/libs/features/spell/src/spell-dbc/effects/spell-dbc-spell-effect/spell-dbc-spell-effect.component.ts
@@ -10,7 +10,7 @@ import {
 import { ModelForm } from '@keira/shared/utils';
 import { SpellDbcSpellEffectFieldPrefix } from './spell-dbc-spell-effect.model';
 import { FlagsSelectorBtnComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 
 @Component({
@@ -23,7 +23,7 @@ import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
     TranslateDirective,
     TranslatePipe,
     SingleValueSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     FlagsSelectorBtnComponent,
   ],
 })

--- a/libs/features/spell/src/spell-dbc/flags/spell-dbc-flags.component.spec.ts
+++ b/libs/features/spell/src/spell-dbc/flags/spell-dbc-flags.component.spec.ts
@@ -6,8 +6,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { SpellDbc } from '@keira/shared/acore-world-model';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ModelForm } from '@keira/shared/utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ModalDirective } from 'ngx-bootstrap/modal';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 import { SpellHandlerService } from '../../spell-handler.service';
 
@@ -29,9 +29,9 @@ describe('SpellDbcFlagsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        ModalModule,
+        ModalDirective,
         ToastrModule.forRoot(),
-        TooltipModule,
+        TooltipDirective,
         RouterTestingModule,
         TranslateTestingModule,
         TestHostComponent,

--- a/libs/features/spell/src/spell-dbc/flags/spell-dbc-flags.component.ts
+++ b/libs/features/spell/src/spell-dbc/flags/spell-dbc-flags.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@keira/shared/acore-world-model';
 import { ModelForm } from '@keira/shared/utils';
 
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
 
@@ -20,7 +20,7 @@ import { FlagsSelectorBtnComponent } from '@keira/shared/selectors';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-spell-dbc-flags',
   templateUrl: './spell-dbc-flags.component.html',
-  imports: [FormsModule, ReactiveFormsModule, TranslateDirective, TranslatePipe, FlagsSelectorBtnComponent, TooltipModule],
+  imports: [FormsModule, ReactiveFormsModule, TranslateDirective, TranslatePipe, FlagsSelectorBtnComponent, TooltipDirective],
 })
 export class SpellDbcFlagsComponent {
   readonly SPELL_DBC_ATTRIBUTES_FLAGS = SPELL_DBC_ATTRIBUTES_FLAGS;

--- a/libs/features/spell/src/spell-dbc/items/spell-dbc-items.component.spec.ts
+++ b/libs/features/spell/src/spell-dbc/items/spell-dbc-items.component.spec.ts
@@ -6,8 +6,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { SpellDbc } from '@keira/shared/acore-world-model';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ModelForm } from '@keira/shared/utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ModalDirective } from 'ngx-bootstrap/modal';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 import { SpellHandlerService } from '../../spell-handler.service';
 
@@ -54,9 +54,9 @@ describe('SpellDbcItemsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        ModalModule,
+        ModalDirective,
         ToastrModule.forRoot(),
-        TooltipModule,
+        TooltipDirective,
         RouterTestingModule,
         TranslateTestingModule,
         TestHostComponent,

--- a/libs/features/spell/src/spell-dbc/items/spell-dbc-items.component.ts
+++ b/libs/features/spell/src/spell-dbc/items/spell-dbc-items.component.ts
@@ -3,7 +3,7 @@ import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ITEM_CLASS, SPELL_DBC_INVENTORY_TYPE, SPELL_DBC_ITEM_SUBCLASS, SpellDbc, TOTEM_CATEGORY } from '@keira/shared/acore-world-model';
 import { ModelForm } from '@keira/shared/utils';
 
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { FlagsSelectorBtnComponent, ItemSelectorBtnComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 
@@ -17,7 +17,7 @@ import { FlagsSelectorBtnComponent, ItemSelectorBtnComponent, SingleValueSelecto
     TranslateDirective,
     TranslatePipe,
     SingleValueSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     FlagsSelectorBtnComponent,
     ItemSelectorBtnComponent,
   ],

--- a/libs/features/spell/src/spell-dbc/misc/spell-dbc-misc.component.spec.ts
+++ b/libs/features/spell/src/spell-dbc/misc/spell-dbc-misc.component.spec.ts
@@ -6,8 +6,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { SpellDbc } from '@keira/shared/acore-world-model';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ModelForm } from '@keira/shared/utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ModalDirective } from 'ngx-bootstrap/modal';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 import { SpellHandlerService } from '../../spell-handler.service';
 import { SpellDbcService } from '../spell-dbc.service';
@@ -39,9 +39,9 @@ describe('SpellDbcMiscComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        ModalModule,
+        ModalDirective,
         ToastrModule.forRoot(),
-        TooltipModule,
+        TooltipDirective,
         RouterTestingModule,
         TranslateTestingModule,
         TestHostComponent,

--- a/libs/features/spell/src/spell-dbc/misc/spell-dbc-misc.component.ts
+++ b/libs/features/spell/src/spell-dbc/misc/spell-dbc-misc.component.ts
@@ -3,13 +3,13 @@ import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ModelForm } from '@keira/shared/utils';
 import { SpellDbc } from '@keira/shared/acore-world-model';
 import { TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-spell-dbc-misc',
   templateUrl: './spell-dbc-misc.component.html',
-  imports: [FormsModule, ReactiveFormsModule, TooltipModule, TranslatePipe],
+  imports: [FormsModule, ReactiveFormsModule, TooltipDirective, TranslatePipe],
 })
 export class SpellDbcMiscComponent {
   readonly formGroup = input.required<FormGroup<ModelForm<SpellDbc>>>();

--- a/libs/features/spell/src/spell-dbc/spell-dbc.component.integration.spec.ts
+++ b/libs/features/spell/src/spell-dbc/spell-dbc.component.integration.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { SpellDbc } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { SpellHandlerService } from '../spell-handler.service';
@@ -27,7 +27,7 @@ describe('SpellDbc integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, SpellDbcComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, SpellDbcComponent, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/features/spell/src/spell-dbc/spell-dbc.component.ts
+++ b/libs/features/spell/src/spell-dbc/spell-dbc.component.ts
@@ -10,7 +10,7 @@ import { SpellDbcItemsComponent } from './items/spell-dbc-items.component';
 import { SpellDbcEffectsComponent } from './effects/spell-dbc-effects.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SpellDbcBaseComponent } from './base/spell-dbc-base.component';
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { TabDirective, TabsetComponent } from 'ngx-bootstrap/tabs';
 import { TranslateDirective } from '@ngx-translate/core';
 
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
@@ -23,7 +23,8 @@ import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor
     TopBarComponent,
     TranslateDirective,
     QueryOutputComponent,
-    TabsModule,
+    TabsetComponent,
+    TabDirective,
     SpellDbcBaseComponent,
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/spell/src/spell-dbc/texts/spell-dbc-locale/spell-dbc-locale.component.spec.ts
+++ b/libs/features/spell/src/spell-dbc/texts/spell-dbc-locale/spell-dbc-locale.component.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ModelForm } from '@keira/shared/utils';
 import { SpellDbc } from '@keira/shared/acore-world-model';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 import { SpellHandlerService } from '../../../spell-handler.service';
 import { SpellDbcService } from '../../spell-dbc.service';
@@ -40,7 +40,7 @@ describe('SpellDbcLocaleComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         ToastrModule.forRoot(),
-        TooltipModule,
+        TooltipDirective,
         RouterTestingModule,
         TranslateTestingModule,
         TestHostComponent,

--- a/libs/features/spell/src/spell-dbc/texts/spell-dbc-texts.component.spec.ts
+++ b/libs/features/spell/src/spell-dbc/texts/spell-dbc-texts.component.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ModelForm } from '@keira/shared/utils';
 import { SpellDbc } from '@keira/shared/acore-world-model';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 import { SpellHandlerService } from '../../spell-handler.service';
 import { SpellDbcService } from '../spell-dbc.service';
@@ -31,7 +31,7 @@ describe('SpellDbcTextsComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         ToastrModule.forRoot(),
-        TooltipModule,
+        TooltipDirective,
         RouterTestingModule,
         TranslateTestingModule,
         TestHostComponent,

--- a/libs/features/spell/src/spell-dbc/texts/spell-dbc-texts.component.ts
+++ b/libs/features/spell/src/spell-dbc/texts/spell-dbc-texts.component.ts
@@ -5,15 +5,15 @@ import { SpellDbc } from '@keira/shared/acore-world-model';
 import { LOCALES } from './spell-dbc-texts.model';
 import { TranslatePipe } from '@ngx-translate/core';
 import { SpellDbcLocaleComponent } from './spell-dbc-locale/spell-dbc-locale.component';
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { TabDirective, TabsetComponent } from 'ngx-bootstrap/tabs';
 
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-spell-dbc-texts',
   templateUrl: './spell-dbc-texts.component.html',
-  imports: [FormsModule, ReactiveFormsModule, TooltipModule, TabsModule, SpellDbcLocaleComponent, TranslatePipe],
+  imports: [FormsModule, ReactiveFormsModule, TooltipDirective, TabsetComponent, TabDirective, SpellDbcLocaleComponent, TranslatePipe],
 })
 export class SpellDbcTextsComponent {
   readonly LOCALES = LOCALES;

--- a/libs/features/sql-editor/src/sql-editor.component.spec.ts
+++ b/libs/features/sql-editor/src/sql-editor.component.spec.ts
@@ -5,7 +5,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { PageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { QueryError } from 'mysql2';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ClipboardService } from 'ngx-clipboard';
 import { of, throwError } from 'rxjs';
 import { SqlEditorComponent } from './sql-editor.component';
@@ -40,7 +40,7 @@ describe('SqlEditorComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TooltipModule, SqlEditorComponent, TranslateTestingModule],
+      imports: [TooltipDirective, SqlEditorComponent, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/features/sql-editor/src/sql-editor.component.ts
+++ b/libs/features/sql-editor/src/sql-editor.component.ts
@@ -9,7 +9,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 
 import { FormsModule } from '@angular/forms';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { QueryErrorComponent } from '@keira/shared/base-editor-components';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 
@@ -20,7 +20,7 @@ import { CodeEditor } from '@acrodata/code-editor';
   selector: 'keira-sql-editor',
   templateUrl: './sql-editor.component.html',
   styleUrls: ['./sql-editor.component.scss'],
-  imports: [CodeEditor, TooltipModule, FormsModule, QueryErrorComponent, NgxDatatableModule, TranslatePipe],
+  imports: [CodeEditor, TooltipDirective, FormsModule, QueryErrorComponent, NgxDatatableModule, TranslatePipe],
 })
 export class SqlEditorComponent extends SubscriptionHandler implements OnInit {
   private readonly mysqlQueryService = inject(MysqlQueryService);

--- a/libs/features/texts/src/acore-string/acore-string.component.ts
+++ b/libs/features/texts/src/acore-string/acore-string.component.ts
@@ -3,7 +3,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { AcoreString } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { AcoreStringHandlerService } from './acore-string-handler.service';
 import { AcoreStringService } from './acore-string.service';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
@@ -11,7 +11,7 @@ import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './acore-string.component.html',
-  imports: [TranslateDirective, TranslatePipe, ReactiveFormsModule, TooltipModule, QueryOutputComponent, TopBarComponent],
+  imports: [TranslateDirective, TranslatePipe, ReactiveFormsModule, TooltipDirective, QueryOutputComponent, TopBarComponent],
 })
 export class AcoreStringComponent extends SingleRowEditorComponent<AcoreString> {
   override readonly editorService = inject(AcoreStringService);

--- a/libs/features/texts/src/acore-string/acore-string.integration.spec.ts
+++ b/libs/features/texts/src/acore-string/acore-string.integration.spec.ts
@@ -5,7 +5,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { AcoreString } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config';
@@ -37,7 +37,7 @@ describe('Acore String integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, AcoreStringComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, AcoreStringComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/texts/src/acore-string/select-acore-string.integration.spec.ts
+++ b/libs/features/texts/src/acore-string/select-acore-string.integration.spec.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { ACORE_STRING_ENTRY } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { SelectAcoreStringComponent } from './select-acore-string.component';
@@ -23,7 +23,7 @@ describe(`${SelectAcoreStringComponent.name} integration tests`, () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectAcoreStringComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectAcoreStringComponent, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), AcoreStringHandlerService],
     }).compileComponents();
   });

--- a/libs/features/texts/src/broadcast-text/broadcast-text.component.ts
+++ b/libs/features/texts/src/broadcast-text/broadcast-text.component.ts
@@ -5,7 +5,7 @@ import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
 import { LanguageSelectorBtnComponent, SingleValueSelectorBtnComponent, SoundEntriesSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { BroadcastTextHandlerService } from './broadcast-text-handler.service';
 import { BroadcastTextService } from './broadcast-text.service';
 
@@ -19,7 +19,7 @@ import { BroadcastTextService } from './broadcast-text.service';
     QueryOutputComponent,
     ReactiveFormsModule,
     SingleValueSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     LanguageSelectorBtnComponent,
     SoundEntriesSelectorBtnComponent,
   ],

--- a/libs/features/texts/src/broadcast-text/broadcast-text.integration.spec.ts
+++ b/libs/features/texts/src/broadcast-text/broadcast-text.integration.spec.ts
@@ -5,7 +5,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { BroadcastText } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config';
@@ -41,7 +41,7 @@ describe('BroadcastText integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, BroadcastTextComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, BroadcastTextComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/texts/src/broadcast-text/select-broadcast-text.integration.spec.ts
+++ b/libs/features/texts/src/broadcast-text/select-broadcast-text.integration.spec.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { BROADCAST_TEXT_ID } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { SelectBroadcastTextComponent } from './select-broadcast-text.component';
@@ -23,7 +23,7 @@ describe(`${SelectBroadcastTextComponent.name} integration tests`, () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectBroadcastTextComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectBroadcastTextComponent, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), BroadcastTextHandlerService],
     }).compileComponents();
   });

--- a/libs/features/texts/src/npc-text/npc-text-fields-group.component.ts
+++ b/libs/features/texts/src/npc-text/npc-text-fields-group.component.ts
@@ -4,13 +4,13 @@ import { EMOTE, NpcText } from '@keira/shared/acore-world-model';
 import { LanguageSelectorBtnComponent, SingleValueSelectorBtnComponent } from '@keira/shared/selectors';
 import { ModelForm } from '@keira/shared/utils';
 import { TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './npc-text-fields-group.component.html',
   selector: 'keira-npc-text-fields-group',
-  imports: [TranslatePipe, ReactiveFormsModule, SingleValueSelectorBtnComponent, TooltipModule, LanguageSelectorBtnComponent],
+  imports: [TranslatePipe, ReactiveFormsModule, SingleValueSelectorBtnComponent, TooltipDirective, LanguageSelectorBtnComponent],
 })
 export class NpcTextFieldsGroupComponent {
   formGroup = input.required<FormGroup<ModelForm<NpcText>>>();

--- a/libs/features/texts/src/npc-text/npc-text.component.ts
+++ b/libs/features/texts/src/npc-text/npc-text.component.ts
@@ -5,14 +5,13 @@ import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor
 import { NpcTextService } from './npc-text.service';
 import { NpcTextHandlerService } from './npc-text-handler.service';
 import { ReactiveFormsModule } from '@angular/forms';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { NpcText } from '@keira/shared/acore-world-model';
 import { NpcTextFieldsGroupComponent } from './npc-text-fields-group.component';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './npc-text.component.html',
-  imports: [TopBarComponent, TranslateDirective, QueryOutputComponent, ReactiveFormsModule, TooltipModule, NpcTextFieldsGroupComponent],
+  imports: [TopBarComponent, TranslateDirective, QueryOutputComponent, ReactiveFormsModule, NpcTextFieldsGroupComponent],
 })
 export class NpcTextComponent extends SingleRowEditorComponent<NpcText> {
   protected override readonly editorService = inject(NpcTextService);

--- a/libs/features/texts/src/npc-text/npc-text.integration.spec.ts
+++ b/libs/features/texts/src/npc-text/npc-text.integration.spec.ts
@@ -5,7 +5,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { NpcText } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config';
@@ -125,7 +125,7 @@ describe('NpcText integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, NpcTextComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, NpcTextComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/texts/src/npc-text/select-npc-text.integration.spec.ts
+++ b/libs/features/texts/src/npc-text/select-npc-text.integration.spec.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { NPC_TEXT_ID } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { SelectNpcTextComponent } from './select-npc-text.component';
@@ -23,7 +23,7 @@ describe(`${SelectNpcTextComponent.name} integration tests`, () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectNpcTextComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectNpcTextComponent, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), NpcTextHandlerService],
     }).compileComponents();
   });

--- a/libs/features/texts/src/page-text/page-text.component.ts
+++ b/libs/features/texts/src/page-text/page-text.component.ts
@@ -5,13 +5,13 @@ import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor
 import { PageTextService } from './page-text.service';
 import { PageTextHandlerService } from './page-text-handler.service';
 import { ReactiveFormsModule } from '@angular/forms';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { PageText } from '@keira/shared/acore-world-model';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './page-text.component.html',
-  imports: [TopBarComponent, TranslateDirective, TranslatePipe, QueryOutputComponent, ReactiveFormsModule, TooltipModule],
+  imports: [TopBarComponent, TranslateDirective, TranslatePipe, QueryOutputComponent, ReactiveFormsModule, TooltipDirective],
 })
 export class PageTextComponent extends SingleRowEditorComponent<PageText> {
   protected override readonly editorService = inject(PageTextService);

--- a/libs/features/texts/src/page-text/page-text.integration.spec.ts
+++ b/libs/features/texts/src/page-text/page-text.integration.spec.ts
@@ -5,7 +5,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { EditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { PageText } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config';
@@ -29,7 +29,7 @@ describe('PageText integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, PageTextComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, PageTextComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/features/texts/src/page-text/select-page-text.integration.spec.ts
+++ b/libs/features/texts/src/page-text/select-page-text.integration.spec.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SelectPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
 import { PAGE_TEXT_ID } from '@keira/shared/acore-world-model';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { SelectPageTextComponent } from './select-page-text.component';
@@ -23,7 +23,7 @@ describe(`${SelectPageTextComponent.name} integration tests`, () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, SelectPageTextComponent, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, SelectPageTextComponent, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), PageTextHandlerService],
     }).compileComponents();
   });

--- a/libs/features/trainer/src/edit-trainer/trainer.component.spec.ts
+++ b/libs/features/trainer/src/edit-trainer/trainer.component.spec.ts
@@ -5,7 +5,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { TrainerHandlerService } from '../trainer-handler.service';
@@ -23,7 +23,7 @@ describe('TrainerComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, ToastrModule.forRoot(), TestHostComponent, TrainerComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ModalDirective, ToastrModule.forRoot(), TestHostComponent, TrainerComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), TrainerHandlerService],
     }).compileComponents();
   });

--- a/libs/features/trainer/src/edit-trainer/trainer.component.ts
+++ b/libs/features/trainer/src/edit-trainer/trainer.component.ts
@@ -3,7 +3,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TRAINER_TYPE, Trainer } from '@keira/shared/acore-world-model';
 import { SingleRowEditorComponent } from '@keira/shared/base-abstract-classes';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { TrainerService } from './trainer.service';
 import { TrainerHandlerService } from '../trainer-handler.service';
 import { QueryOutputComponent, TopBarComponent } from '@keira/shared/base-editor-components';
@@ -19,7 +19,7 @@ import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
     TranslatePipe,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     QueryOutputComponent,
     GenericOptionSelectorComponent,
   ],

--- a/libs/features/trainer/src/select-trainer/select-trainer.component.spec.ts
+++ b/libs/features/trainer/src/select-trainer/select-trainer.component.spec.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { TrainerHandlerService } from '../trainer-handler.service';
@@ -16,7 +16,7 @@ import { SelectTrainerService } from './select-trainer.service';
 describe('SelectTrainerComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, ToastrModule.forRoot(), SelectTrainerComponent, RouterTestingModule, TranslateTestingModule],
+      imports: [ModalDirective, ToastrModule.forRoot(), SelectTrainerComponent, RouterTestingModule, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), TrainerHandlerService],
     }).compileComponents();
   });

--- a/libs/features/trainer/src/trainer-spell/trainer-spell.component.ts
+++ b/libs/features/trainer/src/trainer-spell/trainer-spell.component.ts
@@ -8,7 +8,7 @@ import { SqliteQueryService } from '@keira/shared/db-layer';
 import { SkillSelectorBtnComponent, SpellSelectorBtnComponent } from '@keira/shared/selectors';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { TrainerHandlerService } from '../trainer-handler.service';
 import { TrainerSpellService } from './trainer-spell.service';
 
@@ -25,7 +25,7 @@ import { TrainerSpellService } from './trainer-spell.service';
     FormsModule,
     ReactiveFormsModule,
     SpellSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     SkillSelectorBtnComponent,
     EditorButtonsComponent,
     NgxDatatableModule,

--- a/libs/main/connection-window/src/connection-window.component.spec.ts
+++ b/libs/main/connection-window/src/connection-window.component.spec.ts
@@ -4,7 +4,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { PageObject, Spied, TranslateTestingModule } from '@keira/shared/test-utils';
 import { QueryError } from 'mysql2';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { of, throwError } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
 
@@ -94,7 +94,7 @@ describe('ConnectionWindowComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TooltipModule, ConnectionWindowComponent, TranslateTestingModule],
+      imports: [TooltipDirective, ConnectionWindowComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/main/connection-window/src/connection-window.component.ts
+++ b/libs/main/connection-window/src/connection-window.component.ts
@@ -6,8 +6,8 @@ import { QueryError } from 'mysql2';
 import packageInfo from '../../../../package.json';
 
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { BsDropdownDirective, BsDropdownMenuDirective, BsDropdownToggleDirective } from 'ngx-bootstrap/dropdown';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 
 import { QueryErrorComponent } from '@keira/shared/base-editor-components';
 import { ElectronService } from '@keira/shared/common-services';
@@ -24,10 +24,12 @@ import { ModelForm, SubscriptionHandler } from '@keira/shared/utils';
   imports: [
     FormsModule,
     ReactiveFormsModule,
-    BsDropdownModule,
+    BsDropdownDirective,
+    BsDropdownToggleDirective,
+    BsDropdownMenuDirective,
     TranslateDirective,
     TranslatePipe,
-    TooltipModule,
+    TooltipDirective,
     QueryErrorComponent,
     SwitchLanguageComponent,
   ],

--- a/libs/main/main-window/src/sidebar/logout-btn/logout-btn.component.spec.ts
+++ b/libs/main/main-window/src/sidebar/logout-btn/logout-btn.component.spec.ts
@@ -4,7 +4,7 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { Spied, TranslateTestingModule } from '@keira/shared/test-utils';
-import { BsModalService, ModalModule } from 'ngx-bootstrap/modal';
+import { BsModalService, ModalDirective } from 'ngx-bootstrap/modal';
 import { LogoutBtnComponent } from './logout-btn.component';
 import { LoginConfigService } from '@keira/shared/login-config';
 import { ModalConfirmComponent } from '@keira/shared/base-editor-components';
@@ -13,7 +13,7 @@ import { LocationService } from '@keira/shared/common-services';
 describe('LogoutBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, LogoutBtnComponent, ModalConfirmComponent, TranslateTestingModule],
+      imports: [ModalDirective, LogoutBtnComponent, ModalConfirmComponent, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/main/main-window/src/sidebar/unsaved-icon/unsaved-icon.component.spec.ts
+++ b/libs/main/main-window/src/sidebar/unsaved-icon/unsaved-icon.component.spec.ts
@@ -1,14 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { TranslateTestingModule } from '@keira/shared/test-utils';
 import { UnsavedIconComponent } from './unsaved-icon.component';
 
 describe('UnsavedIconComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TranslateTestingModule, TooltipModule, UnsavedIconComponent],
+      imports: [TranslateTestingModule, TooltipDirective, UnsavedIconComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/main/main-window/src/sidebar/unsaved-icon/unsaved-icon.component.ts
+++ b/libs/main/main-window/src/sidebar/unsaved-icon/unsaved-icon.component.ts
@@ -1,12 +1,12 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-unsaved-icon',
   templateUrl: './unsaved-icon.component.html',
   styleUrls: ['./unsaved-icon.component.scss'],
-  imports: [TooltipModule, TranslatePipe],
+  imports: [TooltipDirective, TranslatePipe],
 })
 export class UnsavedIconComponent {}

--- a/libs/shared/base-editor-components/src/query-output/query-output.component.spec.ts
+++ b/libs/shared/base-editor-components/src/query-output/query-output.component.spec.ts
@@ -8,7 +8,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { EditorService } from '@keira/shared/base-abstract-classes';
 import { TableRow } from '@keira/shared/constants';
 import { QueryOutputComponentPage, TranslateTestingModule } from '@keira/shared/test-utils';
-import { BsModalService, ModalModule } from 'ngx-bootstrap/modal';
+import { BsModalService, ModalDirective } from 'ngx-bootstrap/modal';
 import { ClipboardService } from 'ngx-clipboard';
 import { HighlightjsWrapperComponent } from '../highlightjs-wrapper/highlightjs-wrapper.component';
 import { QueryErrorComponent } from './query-error/query-error.component';
@@ -48,7 +48,7 @@ describe('QueryOutputComponent', () => {
         BrowserModule,
         FormsModule,
         HighlightjsWrapperComponent,
-        ModalModule,
+        ModalDirective,
         TranslateTestingModule,
         TestHostComponent,
         QueryOutputComponent,

--- a/libs/shared/loot-editor/src/loot-editor.component.ts
+++ b/libs/shared/loot-editor/src/loot-editor.component.ts
@@ -13,7 +13,7 @@ import { FlagsSelectorBtnComponent, ItemSelectorBtnComponent } from '@keira/shar
 import { compareObjFn, SubscriptionHandler } from '@keira/shared/utils';
 import { TranslatePipe } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ReferenceViewerComponent } from './reference-viewer.component';
 
 @Component({
@@ -27,7 +27,7 @@ import { ReferenceViewerComponent } from './reference-viewer.component';
     ReactiveFormsModule,
     IconComponent,
     ItemSelectorBtnComponent,
-    TooltipModule,
+    TooltipDirective,
     FlagsSelectorBtnComponent,
     EditorButtonsComponent,
     NgxDatatableModule,

--- a/libs/shared/loot-editor/src/reference-viewer.component.spec.ts
+++ b/libs/shared/loot-editor/src/reference-viewer.component.spec.ts
@@ -5,7 +5,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { LootTemplate } from '@keira/shared/acore-world-model';
 import { PageObject } from '@keira/shared/test-utils';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { of } from 'rxjs';
 import { ReferenceViewerComponent } from './reference-viewer.component';
 import { ReferenceViewerService } from './reference-viewer.service';
@@ -31,7 +31,7 @@ class TestHostComponent {
 describe('ReferenceViewerComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TooltipModule, TestHostComponent, ReferenceViewerComponent],
+      imports: [TooltipDirective, TestHostComponent, ReferenceViewerComponent],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/shared/loot-editor/src/reference-viewer.component.ts
+++ b/libs/shared/loot-editor/src/reference-viewer.component.ts
@@ -7,7 +7,7 @@ import { IconComponent } from '@keira/shared/base-editor-components';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { SubscriptionHandler } from '@keira/shared/utils';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { ReferenceViewerService } from './reference-viewer.service';
 
 @Component({
@@ -15,7 +15,7 @@ import { ReferenceViewerService } from './reference-viewer.service';
   selector: 'keira-reference-viewer',
   templateUrl: './reference-viewer.component.html',
   styleUrls: ['./loot-editor.component.scss'],
-  imports: [TooltipModule, NgxDatatableModule, IconComponent, AsyncPipe],
+  imports: [TooltipDirective, NgxDatatableModule, IconComponent, AsyncPipe],
 })
 export class ReferenceViewerComponent extends SubscriptionHandler implements OnChanges {
   readonly referenceId = input.required<number>();

--- a/libs/shared/map-viewer/map-viewer.component.ts
+++ b/libs/shared/map-viewer/map-viewer.component.ts
@@ -1,7 +1,7 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal, viewChild } from '@angular/core';
 import { TranslateDirective } from '@ngx-translate/core';
-import { ModalDirective, ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import {
   CAPITAL_AREA_IDS,
   MAP_CANVAS_H,
@@ -18,7 +18,7 @@ import { MapViewerService } from './map-viewer.service';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'keira-map-viewer',
-  imports: [TranslateDirective, NgTemplateOutlet, ModalModule],
+  imports: [TranslateDirective, NgTemplateOutlet, ModalDirective],
   templateUrl: './map-viewer.component.html',
   styleUrl: './map-viewer.component.scss',
 })

--- a/libs/shared/model-3d-viewer/src/model-3d-viewer.component.spec.ts
+++ b/libs/shared/model-3d-viewer/src/model-3d-viewer.component.spec.ts
@@ -8,7 +8,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { KEIRA_APP_CONFIG_TOKEN, KEIRA_MOCK_CONFIG } from '@keira/shared/config';
 import { MysqlQueryService } from '@keira/shared/db-layer';
 import { GenericOptionSelectorComponent } from '@keira/shared/selectors';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { of } from 'rxjs';
 import { Model3DViewerComponent } from './model-3d-viewer.component';
 import { CONTENT_WOTLK, Gender, InventoryType, MODEL_TYPE, Race, VIEWER_TYPE } from './model-3d-viewer.model';
@@ -16,7 +16,7 @@ import { CONTENT_WOTLK, Gender, InventoryType, MODEL_TYPE, Race, VIEWER_TYPE } f
 describe('Model3DViewerComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, ReactiveFormsModule, GenericOptionSelectorComponent, Model3DViewerComponent],
+      imports: [ModalDirective, ReactiveFormsModule, GenericOptionSelectorComponent, Model3DViewerComponent],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/shared/sai-editor/src/sai-editor.component.integration.spec.ts
+++ b/libs/shared/sai-editor/src/sai-editor.component.integration.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { SAI_TYPES, SMART_ACTION_CAST_TRIGGERED_FLAGS, SmartScripts } from '@keira/shared/acore-world-model';
 import { MultiRowEditorPageObject, TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 import { instance, mock } from 'ts-mockito';
@@ -109,7 +109,7 @@ describe('SaiEditorComponent integration tests', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ToastrModule.forRoot(), ModalModule, RouterTestingModule, TranslateTestingModule],
+      imports: [ToastrModule.forRoot(), ModalDirective, RouterTestingModule, TranslateTestingModule],
       providers: [
         provideZonelessChangeDetection(),
         provideNoopAnimations(),

--- a/libs/shared/sai-editor/src/sai-editor.component.ts
+++ b/libs/shared/sai-editor/src/sai-editor.component.ts
@@ -68,7 +68,7 @@ import { SaiEditorService } from './sai-editor.service';
 import { SaiHandlerService } from './sai-handler.service';
 import { TimedActionlistComponent } from './timed-actionlist/timed-actionlist.component';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { SaiTopBarComponent } from './sai-top-bar/sai-top-bar.component';
@@ -91,7 +91,7 @@ import { AsyncPipe } from '@angular/common';
     QueryOutputComponent,
     FormsModule,
     ReactiveFormsModule,
-    TooltipModule,
+    TooltipDirective,
     FlagsSelectorBtnComponent,
     EditorButtonsComponent,
     NgxDatatableModule,

--- a/libs/shared/selectors/src/selectors/area-selector/area-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/area-selector/area-selector-btn.component.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { AreaSelectorBtnComponent } from './area-selector-btn.component';
 
 describe('AreaSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, AreaSelectorBtnComponent],
+      imports: [ModalDirective, AreaSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/base-selector/base-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/base-selector/base-selector-btn.component.spec.ts
@@ -6,7 +6,7 @@ import { FormsModule, ReactiveFormsModule, UntypedFormControl } from '@angular/f
 import { BrowserModule } from '@angular/platform-browser';
 import { TranslateTestingModule } from '@keira/shared/test-utils';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { BsModalService, ModalModule } from 'ngx-bootstrap/modal';
+import { BsModalService, ModalDirective } from 'ngx-bootstrap/modal';
 import { instance, mock } from 'ts-mockito';
 import { ItemSelectorBtnComponent } from '../item-selector/item-selector-btn.component';
 import { ItemSelectorModalComponent } from '../item-selector/item-selector-modal.component';
@@ -15,7 +15,7 @@ import { HighlightjsWrapperComponent } from '@keira/shared/base-editor-component
 
 @NgModule({
   imports: [
-    ModalModule,
+    ModalDirective,
     BrowserModule,
     FormsModule,
     ReactiveFormsModule,
@@ -33,7 +33,7 @@ describe('BaseSelectorBtnComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, TestModule, ItemSelectorBtnComponent],
+      imports: [ModalDirective, TestModule, ItemSelectorBtnComponent],
     }).compileComponents();
   });
 

--- a/libs/shared/selectors/src/selectors/creature-selector/creature-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/creature-selector/creature-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { CreatureSelectorBtnComponent } from './creature-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('CreatureSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, CreatureSelectorBtnComponent],
+      imports: [ModalDirective, CreatureSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/faction-selector/faction-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/faction-selector/faction-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { FactionSelectorBtnComponent } from './faction-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('FactionSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, FactionSelectorBtnComponent],
+      imports: [ModalDirective, FactionSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/faction-selector/quest-faction-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/faction-selector/quest-faction-selector-btn.component.spec.ts
@@ -2,14 +2,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { QuestFactionSelectorBtnComponent } from './quest-faction-selector-btn.component';
 import { FactionSelectorBtnComponent } from './faction-selector-btn.component';
 
 describe('QuestFactionSelectorBtnComponent', () => {
   function setup() {
     TestBed.configureTestingModule({
-      imports: [ModalModule, FactionSelectorBtnComponent],
+      imports: [ModalDirective, FactionSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
 

--- a/libs/shared/selectors/src/selectors/flags-selector/flags-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/flags-selector/flags-selector-btn.component.spec.ts
@@ -2,12 +2,12 @@ import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { FlagsSelectorBtnComponent } from './flags-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('FlagsSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, FlagsSelectorBtnComponent],
+      imports: [ModalDirective, FlagsSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/game-tele-selector/game-tele-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/game-tele-selector/game-tele-selector-btn.component.spec.ts
@@ -2,12 +2,12 @@ import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { GameTeleSelectorBtnComponent } from './game-tele-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('GameTeleSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, GameTeleSelectorBtnComponent],
+      imports: [ModalDirective, GameTeleSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/gameobject-selector/gameobject-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/gameobject-selector/gameobject-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { GameobjectSelectorBtnComponent } from './gameobject-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('GameobjectSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, GameobjectSelectorBtnComponent],
+      imports: [ModalDirective, GameobjectSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/holiday-selector/holiday-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/holiday-selector/holiday-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { HolidaySelectorBtnComponent } from './holiday-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('HolidaySelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, HolidaySelectorBtnComponent],
+      imports: [ModalDirective, HolidaySelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/item-enchantment-selector/item-enchantment-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/item-enchantment-selector/item-enchantment-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { ItemEnchantmentSelectorBtnComponent } from './item-enchantment-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('ItemEnchantmentSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, ItemEnchantmentSelectorBtnComponent],
+      imports: [ModalDirective, ItemEnchantmentSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/item-extended-cost-selector/item-extended-cost-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/item-extended-cost-selector/item-extended-cost-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { ItemExtendedCostSelectorBtnComponent } from './item-extended-cost-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('ItemExtendedCostSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, ItemExtendedCostSelectorBtnComponent],
+      imports: [ModalDirective, ItemExtendedCostSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/item-limit-category-selector/item-limit-category-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/item-limit-category-selector/item-limit-category-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { ItemLimitCategorySelectorBtnComponent } from './item-limit-category-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('ItemLimitCategorySelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, ItemLimitCategorySelectorBtnComponent],
+      imports: [ModalDirective, ItemLimitCategorySelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/item-selector/item-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/item-selector/item-selector-btn.component.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { ItemSelectorBtnComponent } from './item-selector-btn.component';
 
 describe('ItemSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, ItemSelectorBtnComponent],
+      imports: [ModalDirective, ItemSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/language-selector/language-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/language-selector/language-selector-btn.component.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { LanguageSelectorBtnComponent } from './language-selector-btn.component';
 
 describe('LanguageSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, LanguageSelectorBtnComponent],
+      imports: [ModalDirective, LanguageSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/map-selector/map-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/map-selector/map-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { MapSelectorBtnComponent } from './map-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('MapSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, MapSelectorBtnComponent],
+      imports: [ModalDirective, MapSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/npc-text-selector/npc-text-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/npc-text-selector/npc-text-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { NpcTextSelectorBtnComponent } from './npc-text-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('NpcTextSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, NpcTextSelectorBtnComponent],
+      imports: [ModalDirective, NpcTextSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/quest-selector/quest-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/quest-selector/quest-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { QuestSelectorBtnComponent } from './quest-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('QuestSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, QuestSelectorBtnComponent],
+      imports: [ModalDirective, QuestSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/single-value-selector/single-value-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/single-value-selector/single-value-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { SingleValueSelectorBtnComponent } from './single-value-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('SingleValueSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, SingleValueSelectorBtnComponent],
+      imports: [ModalDirective, SingleValueSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/skill-selector/skill-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/skill-selector/skill-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { SkillSelectorBtnComponent } from './skill-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('SkillSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, SkillSelectorBtnComponent],
+      imports: [ModalDirective, SkillSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/sound-entries-selector/sound-entries-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/sound-entries-selector/sound-entries-selector-btn.component.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { SoundEntriesSelectorBtnComponent } from './sound-entries-selector-btn.component';
 
 describe('SoundEntriesSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, SoundEntriesSelectorBtnComponent],
+      imports: [ModalDirective, SoundEntriesSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/selectors/src/selectors/spell-selector/spell-selector-btn.component.spec.ts
+++ b/libs/shared/selectors/src/selectors/spell-selector/spell-selector-btn.component.spec.ts
@@ -3,12 +3,12 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { SpellSelectorBtnComponent } from './spell-selector-btn.component';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 describe('SpellSelectorBtnComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, SpellSelectorBtnComponent],
+      imports: [ModalDirective, SpellSelectorBtnComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/switch-language/src/switch-language.component.spec.ts
+++ b/libs/shared/switch-language/src/switch-language.component.spec.ts
@@ -2,13 +2,13 @@ import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { TranslateTestingModule } from '@keira/shared/test-utils';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { SwitchLanguageComponent } from './switch-language.component';
 
 describe('SwitchLanguageComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, TranslateTestingModule, SwitchLanguageComponent],
+      imports: [ModalDirective, TranslateTestingModule, SwitchLanguageComponent],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
     }).compileComponents();
   });

--- a/libs/shared/switch-language/src/switch-language.service.spec.ts
+++ b/libs/shared/switch-language/src/switch-language.service.spec.ts
@@ -4,13 +4,13 @@ import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { TranslateTestingModule } from '@keira/shared/test-utils';
 import { TranslateService } from '@ngx-translate/core';
-import { ModalModule } from 'ngx-bootstrap/modal';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 import { SwitchLanguageService } from './switch-language.service';
 
 describe('SwitchLanguageService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ModalModule, TranslateTestingModule],
+      imports: [ModalDirective, TranslateTestingModule],
       providers: [provideZonelessChangeDetection(), provideNoopAnimations(), SwitchLanguageService],
     }).compileComponents();
   });


### PR DESCRIPTION
Follow-up to #3867, same idea applied to ngx-bootstrap. All of its declarables have been standalone since v21, so the umbrella modules were only pulling in dead weight.

What changed:

- `TooltipModule` → `TooltipDirective` (the bulk of the diff, ~60 files)
- `TabsModule` → `TabsetComponent` + `TabDirective` in the spell dbc components
- `BsDropdownModule` → `BsDropdownDirective` + `BsDropdownToggleDirective` + `BsDropdownMenuDirective` in the connection window
- `CollapseModule` → `CollapseDirective` in the quest preview
- `ModalModule` → `ModalDirective`, mostly in test beds

I also dropped the four ngx-bootstrap entries from `importProvidersFrom` in `main.ts`. None of those modules declares providers (`BsModalService` and friends are `providedIn: 'root'`), so they weren't doing anything there.

Four components turned out to import the tooltip without ever using it: `CreatureFormations`, `CreatureTemplateModel`, `CreatureTemplateResistance` and `NpcText`. NG8113 caught them as soon as the module became a directive, so they're gone too.

Untouched: `FormsModule`, `ReactiveFormsModule`, `NgxDatatableModule`, `UiSwitchModule`, `NgxSelectModule` and `ClipboardModule`. Their declarables are still `standalone: false`, so those modules have to stay. There's a note about all of this in the conventions doc now (85a91719).

Build, lint and the full test suite are green locally.
