### PR TITLE
ci: publish release binaries unzipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,14 +70,11 @@ jobs:
           mv "release/${APP_NAME}-${VERSION}.x86_64.rpm" "${ASSET_BASE}.LINUX.rpm"
           mv "release/${APP_NAME}_${VERSION}_amd64.deb" "${ASSET_BASE}.LINUX.deb"
           mv "release/${APP_NAME}_${VERSION}_amd64.snap" "${ASSET_BASE}.LINUX.snap"
-          for ext in AppImage rpm deb snap; do
-            zip "${ASSET_BASE}.LINUX.${ext}.zip" "${ASSET_BASE}.LINUX.${ext}"
-          done
       - name: Upload assets
         uses: actions/upload-artifact@v7
         with:
           name: linux-assets
-          path: '*.LINUX.*.zip'
+          path: '*.LINUX.*'
           if-no-files-found: error
 
   build-on-mac:
@@ -115,12 +112,11 @@ jobs:
       - name: Prepare release assets
         run: |
           mv "release/${APP_NAME}-${VERSION}${{ matrix.dmg_suffix }}.dmg" "${ASSET_BASE}.${{ matrix.asset_suffix }}.dmg"
-          zip "${ASSET_BASE}.${{ matrix.asset_suffix }}.dmg.zip" "${ASSET_BASE}.${{ matrix.asset_suffix }}.dmg"
       - name: Upload assets
         uses: actions/upload-artifact@v7
         with:
           name: mac-${{ matrix.arch }}-assets
-          path: '*.dmg.zip'
+          path: '*.dmg'
           if-no-files-found: error
 
   build-on-windows:
@@ -146,13 +142,12 @@ jobs:
       - name: Prepare release assets
         run: |
           mv "release/${APP_NAME} ${VERSION}.exe" "${ASSET_BASE}.WINDOWS.exe"
-          7z a "${ASSET_BASE}.WINDOWS.exe.zip" "${ASSET_BASE}.WINDOWS.exe"
         shell: bash
       - name: Upload assets
         uses: actions/upload-artifact@v7
         with:
           name: windows-assets
-          path: '*.WINDOWS.exe.zip'
+          path: '*.WINDOWS.exe'
           if-no-files-found: error
 
   release:
@@ -169,7 +164,7 @@ jobs:
           merge-multiple: true
       - name: Generate checksums
         working-directory: assets
-        run: sha256sum *.zip > SHA256SUMS.txt
+        run: sha256sum -- * > "${RUNNER_TEMP}/SHA256SUMS.txt" && mv "${RUNNER_TEMP}/SHA256SUMS.txt" .
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:


### PR DESCRIPTION
closes #3874

We were wrapping every release asset in a zip. For AppImages that's actively harmful: update tools like Gear Lever can't follow a link to an archive, and [AppImage's own docs](https://docs.appimage.org/packaging-guide/distribution.html#do-not-put-appimages-into-other-archives) ask packagers not to do it. For the rest (dmg, exe, deb, rpm, snap) the extra layer wasn't buying us anything either, so it's gone everywhere.

The renaming stays untouched, assets are still published as `Keira-x.y.z.LINUX.AppImage`, `Keira-x.y.z.WINDOWS.exe`, `Keira-x.y.z.MAC.arm64.dmg` etc.

`SHA256SUMS.txt` now checksums all assets instead of just the zips. It's written to `$RUNNER_TEMP` first and moved in after, otherwise the glob would try to checksum the file it's writing.

One note: `upload-artifact` doesn't preserve the executable bit, but that changes nothing in practice since GitHub release downloads never carry permissions anyway, AppImage users always had to `chmod +x`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release downloads are now provided in their native formats for Linux, macOS, and Windows.
  * Added SHA-256 checksums covering all available release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->